### PR TITLE
split tests according to simulator (very crudely for the moment)

### DIFF
--- a/test/example_all_from_root/run
+++ b/test/example_all_from_root/run
@@ -1,7 +1,8 @@
 source ../test_functions.bsh
 
-expect_passing_example $SVUNIT_INSTALL/examples "IUS -uvm -d CLK_PERIOD=10ns -d RUN_SVUNIT_WITH_UVM_REPORT_MOCK -f all.f" &&
-expect_passing_example $SVUNIT_INSTALL/examples "QUESTA -uvm -d CLK_PERIOD=10ns -d RUN_SVUNIT_WITH_UVM_REPORT_MOCK"
+expect_passing_example $SVUNIT_INSTALL/examples "$1 -uvm -d CLK_PERIOD=10ns -d RUN_SVUNIT_WITH_UVM_REPORT_MOCK -f all.f"
+
+#expect_passing_example $SVUNIT_INSTALL/examples "QUESTA -uvm -d CLK_PERIOD=10ns -d RUN_SVUNIT_WITH_UVM_REPORT_MOCK"
 #expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_express VCS
 
 exit 0

--- a/test/example_modules_apb_slave/run
+++ b/test/example_modules_apb_slave/run
@@ -1,7 +1,8 @@
 source ../test_functions.bsh
 
-expect_passing_example $SVUNIT_INSTALL/examples/modules/apb_slave IUS &&
-expect_passing_example $SVUNIT_INSTALL/examples/modules/apb_slave QUESTA
+expect_passing_example $SVUNIT_INSTALL/examples/modules/apb_slave $1
+
+#expect_passing_example $SVUNIT_INSTALL/examples/modules/apb_slave QUESTA
 #expect_passing_example $SVUNIT_INSTALL/examples/modules/apb_slave VCS
 
 exit 0

--- a/test/example_uvm_report_mock/run
+++ b/test/example_uvm_report_mock/run
@@ -1,6 +1,7 @@
 source ../test_functions.bsh
 
-expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_report_mock "IUS -uvm -define RUN_SVUNIT_WITH_UVM_REPORT_MOCK" &&
-expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_report_mock "QUESTA -uvm -define RUN_SVUNIT_WITH_UVM_REPORT_MOCK"
+expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_report_mock "$1 -uvm -define RUN_SVUNIT_WITH_UVM_REPORT_MOCK"
+
+#expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_report_mock "QUESTA -uvm -define RUN_SVUNIT_WITH_UVM_REPORT_MOCK"
 
 exit 0

--- a/test/example_uvm_simple_model/run
+++ b/test/example_uvm_simple_model/run
@@ -4,13 +4,14 @@ pushd . >/dev/null
 
 cd $SVUNIT_INSTALL/examples/uvm/simple_model
 
-runSVUnit -s IUS -uvm -define UVM_NO_DEPRECATED -c_arg '-uvmhome $INCISIV_HOME/tools/methodology/UVM/CDNS-1.2/sv'
+runSVUnit -s $1 -uvm -define UVM_NO_DEPRECATED -c_arg '-uvmhome $INCISIV_HOME/tools/methodology/UVM/CDNS-1.2/sv'
 
 # check the log output for a PASS from the testrunner
 expect_file run.log
 expect_testrunner_pass run.log
 
 popd >/dev/null
-expect_passing_example $SVUNIT_INSTALL/examples/uvm/simple_model "QUESTA -uvm"
+
+#expect_passing_example $SVUNIT_INSTALL/examples/uvm/simple_model "QUESTA -uvm"
 
 exit 0

--- a/test/example_uvm_simple_model_2/run
+++ b/test/example_uvm_simple_model_2/run
@@ -1,6 +1,6 @@
 source ../test_functions.bsh
 
-expect_uvm_passing_example $SVUNIT_INSTALL/examples/uvm/simple_model simple_model.sv "IUS -uvm" &&
-expect_uvm_passing_example $SVUNIT_INSTALL/examples/uvm/simple_model simple_model.sv "QUESTA -uvm"
+expect_uvm_passing_example $SVUNIT_INSTALL/examples/uvm/simple_model simple_model.sv "$1 -uvm"
+#expect_uvm_passing_example $SVUNIT_INSTALL/examples/uvm/simple_model simple_model.sv "QUESTA -uvm"
 
 exit 0

--- a/test/example_uvm_uvm_express/run
+++ b/test/example_uvm_uvm_express/run
@@ -1,6 +1,7 @@
 source ../test_functions.bsh
 
-expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_express "IUS -U --filelist cov.f -define CLK_PERIOD=10ns"
-expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_express "QUESTA -U -define CLK_PERIOD=10ns"
+expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_express "$1 -U --filelist cov.f -define CLK_PERIOD=10ns"
+
+#expect_passing_example $SVUNIT_INSTALL/examples/uvm/uvm_express "QUESTA -U -define CLK_PERIOD=10ns"
 
 exit 0

--- a/test/run
+++ b/test/run
@@ -1,48 +1,94 @@
+#!/bin/env bash
+
+opts=`getopt -o s: --long sim: -n '$0' -- "$@"`
+eval set -- "$opts"
+
+all_sims=(ius questa vcs)
+sims=()
+
+while true; do
+  case "$1" in
+    -s|--sim)
+      # TODO Add error checking
+      sims=(${sims[@]} "$2")
+      shift 2
+      ;;
+
+    --)
+      shift
+      break
+      ;;
+
+    *)
+      echo "Internal error!"
+      exit 1
+      ;;
+  esac
+done
+
+if [ ${#sims[@]} -eq 0 ]; then
+  sims=${all_sims[@]}
+fi
+
 echo ----------------------------------
 echo Running SVUNIT Regression Suite...
 echo ----------------------------------
-
-# define the individual test groupings
-declare -a frmwrk_tests
-frmwrk_tests=`ls -d frmwrk_*`
-
-declare -a sim_tests
-sim_tests=`ls -d sim_*`
-
-declare -a svunit_base_tests
-svunit_base_tests=`ls -d svunit_base_*`
- 
-declare -a example_tests
-example_tests=`ls -d example_*`
-
-declare -a mock_tests
-mock_tests=`ls -d mock_*`
-
-declare -a util_tests
-util_tests=`ls -d util_*`
+echo
+echo Selected simulators: ${sims[@]}
+echo
 
 
-# define the concatentated master list
-declare -a testlist
-testlist=( ${frmwrk_tests[@]} ${sim_tests[@]} ${svunit_base_tests[@]} ${example_tests[@]} ${mock_tests[@]} ${util_tests[@]})
 
-
-# loop through the master testlist and invoke each test
 pass=1
-for test in ${testlist[@]}; do
-  printf "Running %s... " $test
-  cd $test && ./run > /dev/null 2>&1
-  if [ "$?" != "0" ]; then
-    printf "FAILED\n"
-    pass=0
-  else
-    printf "PASSED\n"
-  fi
 
-  ./clean > /dev/null 2>&1
+function run_testlist {
+  declare -a testlist=("${!1}")
+  local sim=$2
 
-  cd - > /dev/null 2>&1
+  for test in ${testlist[@]}; do
+    printf "Running %s... " $test
+    cd $test && ./run $sim > /dev/null 2>&1
+    if [ "$?" != "0" ]; then
+      printf "FAILED\n"
+      pass=0
+    else
+      printf "PASSED\n"
+    fi
+
+    ./clean > /dev/null 2>&1
+
+    cd - > /dev/null 2>&1
+  done
+}
+
+
+# run the individual test groupings
+declare -a frmwrk_tests
+frmwrk_tests=`ls -v -d frmwrk_*`
+run_testlist frmwrk_tests[@]
+
+for sim in "${sims[@]}"; do
+  declare -a sim_tests
+  sim_tests=`ls -v -d sim_${sim}*`
+  run_testlist sim_tests[@]
+
+  declare -a svunit_base_tests
+  svunit_base_tests=`ls -v -d svunit_base_${sim}_*`
+  run_testlist svunit_base_tests[@]
+
+  declare -a example_tests
+  example_tests=`ls -d example_*`
+  run_testlist example_tests[@] $sim
+
+  declare -a mock_tests
+  mock_tests=`ls -d mock_*_${sim}*`
+  run_testlist mock_tests[@] $sim
+
+  declare -a util_tests
+  util_tests=`ls -d util_*`
+  run_testlist util_tests[@] $sim
 done
+
 
 if [ "$pass" == "1" ]; then
   echo ----------------------------------

--- a/test/util_clk_reset/run
+++ b/test/util_clk_reset/run
@@ -2,6 +2,6 @@ source ../test_functions.bsh
 
 setup
 
-runSVUnit -s questa
+runSVUnit -s $1
 
 expect_testrunner_pass run.log


### PR DESCRIPTION
This is just a trial. Have a look at it and give me feedback if you don't like anything.

The long term plan is to get rid of "sim_ius_mk_", "questa_ius_mk_", etc. and replace them with "mk*", i.e. only one set of tests for the tooling, just like we have for the examples. The simulator to use is passed to each test's 'run' script and it can use it for the 'runSVUnit' call. It can also change some of the arguments that are tool specific.

The yet unsolved problem is how to deal with cases that we can handle in one simulator, but not in another. For example, it's easy in IUS to change the UVM version (as it's done via the simulator command line), but this is more difficult in Questa (as far as I can remember).
