### PR TITLE
Fixed the regular expression that is used to cleanup generated testsuite and testrunner files

### DIFF
--- a/bin/cleanSVUnit
+++ b/bin/cleanSVUnit
@@ -28,8 +28,8 @@ use File::Find;
 
 find({
     wanted => sub {
-                    if (/.*testsuite\.sv$/   or
-                        /.*testrunner\.sv$/
+                    if (/^\..*testsuite\.sv$/   or
+                        /^\..*testrunner\.sv$/
                     ) {
                       unlink;
                     }

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -71,8 +71,8 @@ sub usage () {
 sub clean () {
   find({
       wanted => sub {
-                      if (/.*testsuite\.sv$/   or
-                          /.*testrunner\.sv$/
+                      if (/^\..*testsuite\.sv$/   or
+                          /^\..*testrunner\.sv$/
                       ) {
                         unlink;
                       }


### PR DESCRIPTION
The regex now matches any files that start with . and end with either testsuite.sv or testrunner.sv.  This fixes the issue that caused the svunit_testrunner.sv and svunit_testsuite.sv files to get deleted if the svunit-code directory is located downstream from where the unit tests are run.