### PR TITLE
Updated VCS simulations to specify the top module

### DIFF
--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -151,6 +151,8 @@ $cmd .= " +define+" . join " +define+", @defines if (@defines > 0);
 
 if ($simulator eq "modelsim" or $simulator eq "riviera") {
   $cmd .= qq! @compileargs; vsim @simargs -lib work -c -do "run -all; quit" -l $logfile testrunner!;
+} elsif ($simulator eq "vcs") {
+  $cmd .= " @compileargs @simargs -top testrunner";
 } else {
   $cmd .= " @compileargs @simargs";
 }


### PR DESCRIPTION
This is the same as is currently done with ModelSim.  This cleans up the module hierarchy when debugging in the VCS GUI because by default VCS makes all top level compiled modules as top level in the simulation.