### PR TITLE
Updated FAIL macros with two arguments to work with more complex items

### DIFF
--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -39,7 +39,7 @@
 
 `ifndef FAIL_IF_EQUAL
 `define FAIL_IF_EQUAL(a,b) \
-  if (svunit_pkg::current_tc.fail(`"fail_if_equal`", (a===b), `"a === b`", `__FILE__, `__LINE__)) begin \
+  if (svunit_pkg::current_tc.fail(`"fail_if_equal`", ((a)===(b)), `"(a) === (b)`", `__FILE__, `__LINE__)) begin \
     if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif
@@ -60,7 +60,7 @@
 
 `ifndef FAIL_UNLESS_EQUAL
 `define FAIL_UNLESS_EQUAL(a,b) \
-  if (svunit_pkg::current_tc.fail(`"fail_unless_equal`", (a!==b), `"a !== b`", `__FILE__, `__LINE__)) begin \
+  if (svunit_pkg::current_tc.fail(`"fail_unless_equal`", ((a)!==(b)), `"(a) !== (b)`", `__FILE__, `__LINE__)) begin \
     if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif

--- a/test/sim_3/dut_unit_test.sv
+++ b/test/sim_3/dut_unit_test.sv
@@ -99,6 +99,37 @@ module dut_unit_test;
       `FAIL_IF_LOG(bozo != 2, $psprintf("%s %0d", gum, bozo));
     `SVTEST_END
 
+    // verify FAIL_IF_EQUAL works with ternary operator (should pass)
+    `SVTEST(eighth_test)
+      static logic [3:0] data_a = 4'h7;
+      static logic [3:0] data_b = 4'hf;
+      static logic       select = 0;
+      `FAIL_IF_EQUAL(data_a, select ? data_a : data_b);
+    `SVTEST_END
+
+    // verify FAIL_IF_EQUAL works with ternary operator (should pass)
+    `SVTEST(ninth_test)
+      static logic [3:0] data_a = 4'h7;
+      static logic [3:0] data_b = 4'hf;
+      static logic       select = 1;
+      `FAIL_IF_EQUAL(select ? data_a : data_b, data_b);
+    `SVTEST_END
+
+    // verify FAIL_UNLESS_EQUAL works with ternary operator (should pass)
+    `SVTEST(tenth_test)
+      static logic [3:0] data_a = 4'h7;
+      static logic [3:0] data_b = 4'hf;
+      static logic       select = 0;
+      `FAIL_UNLESS_EQUAL(data_b, select ? data_a : data_b);
+    `SVTEST_END
+
+    // verify FAIL_UNLESS_EQUAL works with ternary operator (should pass)
+    `SVTEST(eleventh_test)
+      static logic [3:0] data_a = 4'h7;
+      static logic [3:0] data_b = 4'hf;
+      static logic       select = 1;
+      `FAIL_UNLESS_EQUAL(select ? data_a : data_b, data_a);
+    `SVTEST_END
   `SVUNIT_TESTS_END
 
 

--- a/test/sim_3/run
+++ b/test/sim_3/run
@@ -17,10 +17,10 @@ for s in ${SVUNIT_SIMULATORS[@]}; do
   expect_string "ERROR: \[0\]\[dut_ut\]: fail_unless: beam == 1 (at .*dut_unit_test.sv line:73)" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: third_test::FAILED" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: fourth_test::RUNNING" run.log &&
-  expect_string "ERROR: \[0\]\[dut_ut\]: fail_if_equal: 'hf === 15 (at .*dut_unit_test.sv line:80)" run.log &&
+  expect_string "ERROR: \[0\]\[dut_ut\]: fail_if_equal: ('hf) === (15) (at .*dut_unit_test.sv line:80)" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: fourth_test::FAILED" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: fifth_test::RUNNING" run.log &&
-  expect_string "ERROR: \[0\]\[dut_ut\]: fail_unless_equal: 15 !== 'ha (at .*dut_unit_test.sv line:86)" run.log &&
+  expect_string "ERROR: \[0\]\[dut_ut\]: fail_unless_equal: (15) !== ('ha) (at .*dut_unit_test.sv line:86)" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: fifth_test::FAILED" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: FAILED" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: sixth_test::RUNNING" run.log &&
@@ -29,6 +29,14 @@ for s in ${SVUNIT_SIMULATORS[@]}; do
   expect_string "INFO:  \[0\]\[dut_ut\]: seventh_test::RUNNING" run.log &&
   expect_string "ERROR: \[0\]\[dut_ut\]: fail_if: bozo != 2 \[ gum is wrong 4 \] (at .*dut_unit_test.sv line:99)" run.log &&
   expect_string "INFO:  \[0\]\[dut_ut\]: seventh_test::FAILED" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: eighth_test::RUNNING" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: eighth_test::PASSED" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: ninth_test::RUNNING" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: ninth_test::PASSED" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: tenth_test::RUNNING" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: tenth_test::PASSED" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: eleventh_test::RUNNING" run.log &&
+  expect_string "INFO:  \[0\]\[dut_ut\]: eleventh_test::PASSED" run.log &&
   expect_string "INFO:  \[0\]\[testrunner\]: FAILED" run.log
 done
 


### PR DESCRIPTION
Updated FAIL macros that take two arguments to have parentheses around the arguments before doing the comparison to ensure the macros work when more complex items are passed in (like ternary expressions).

I also added some unit tests to verify the changes I made.  Hopefully I added the unit tests in the right place.