### PR TITLE
Fixes Issue #34: SVUNIT_CLK_GEN macro causes testcase to end early or hang

### DIFF
--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -26,42 +26,42 @@
 `ifndef FAIL_IF
 `define FAIL_IF(exp) \
   if (svunit_pkg::current_tc.fail(`"fail_if`", (exp), `"exp`", `__FILE__, `__LINE__)) begin \
-    if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+    if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif
 
 `ifndef FAIL_IF_LOG
 `define FAIL_IF_LOG(exp,msg) \
   if (svunit_pkg::current_tc.fail(`"fail_if`", (exp), `"exp`", `__FILE__, `__LINE__, msg)) begin \
-    if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+    if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif
 
 `ifndef FAIL_IF_EQUAL
 `define FAIL_IF_EQUAL(a,b) \
   if (svunit_pkg::current_tc.fail(`"fail_if_equal`", ((a)===(b)), `"(a) === (b)`", `__FILE__, `__LINE__)) begin \
-    if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+    if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif
 
 `ifndef FAIL_UNLESS
 `define FAIL_UNLESS(exp) \
   if (svunit_pkg::current_tc.fail(`"fail_unless`", !(exp), `"exp`", `__FILE__, `__LINE__)) begin \
-    if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+    if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif
 
 `ifndef FAIL_UNLESS_LOG
 `define FAIL_UNLESS_LOG(exp,msg) \
   if (svunit_pkg::current_tc.fail(`"fail_unless`", !(exp), `"exp`", `__FILE__, `__LINE__, msg)) begin \
-    if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+    if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif
 
 `ifndef FAIL_UNLESS_EQUAL
 `define FAIL_UNLESS_EQUAL(a,b) \
   if (svunit_pkg::current_tc.fail(`"fail_unless_equal`", ((a)!==(b)), `"(a) !== (b)`", `__FILE__, `__LINE__)) begin \
-    if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+    if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
   end
 `endif
 
@@ -73,7 +73,7 @@
     stra = a; \
     strb = b; \
     if (svunit_pkg::current_tc.fail(`"fail_if_str_equal`", stra.compare(strb)==0, $sformatf(`"\"%s\" == \"%s\"`",stra,strb), `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
     end \
   end
 `endif
@@ -86,7 +86,7 @@
     stra = a; \
     strb = b; \
     if (svunit_pkg::current_tc.fail(`"fail_unless_str_equal`", stra.compare(strb)!=0, $sformatf(`"\"%s\" != \"%s\"`",stra,strb), `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_test_running()) svunit_pkg::current_tc.give_up(); \
     end \
   end
 `endif
@@ -154,7 +154,7 @@
 \
     `INFO($sformatf(`"%s::RUNNING`", _testName)); \
     svunit_pkg::current_tc = svunit_ut; \
-    svunit_ut.start(); \
+    svunit_ut.start_test(); \
     setup(); \
     fork \
       begin \
@@ -178,7 +178,7 @@
         disable fork; \
       end \
     join \
-    svunit_ut.stop(); \
+    svunit_ut.stop_test(); \
     teardown(); \
     if (svunit_ut.get_error_count() == local_error_count) \
       `INFO($sformatf(`"%s::PASSED`", _testName)); \

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -127,13 +127,16 @@
 */
 `define SVUNIT_TESTS_BEGIN \
   task automatic run(); \
-    `INFO("RUNNING");
+    `INFO("RUNNING"); \
+    svunit_ut.start_testcase();
 
 /*
   Macro: `SVUNIT_TESTS_END
   END a block of unit tests
 */
-`define SVUNIT_TESTS_END endtask
+`define SVUNIT_TESTS_END \
+    svunit_ut.stop_testcase(); \
+    endtask
 
 
 /*
@@ -202,10 +205,10 @@ end \
     initial begin \
         _clk_variable = 0; \
         wait(svunit_ut != null); \
-        forever begin \
-            if( svunit_ut.is_running() ) \
-                #_half_period _clk_variable = !_clk_variable; \
-            else \
-                wait( svunit_ut.is_running() ); \
-        end \
-    end   
+        svunit_ut.wait_for_testcase_start(); \
+        fork \
+          svunit_ut.wait_for_testcase_stop(); \
+          forever begin #_half_period _clk_variable = !_clk_variable; end \
+        join_any \
+        disable fork; \
+    end

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -44,6 +44,13 @@ class svunit_testcase extends svunit_base;
     1 is somewhere between setup and teardown, 0 otherwise
   */
   local bit running = 0;
+  
+  
+  /*
+    Variable: testcase_running
+    1 is when this test case is executing its tests (including each tests setup and teardown), 0 otherwise
+  */
+  local bit testcase_running = 0;
 
 
   /*
@@ -60,6 +67,12 @@ class svunit_testcase extends svunit_base;
   extern function void start();
   extern function void stop();
   extern function bit  is_running();
+  
+  extern task wait_for_testcase_start();
+  extern task wait_for_testcase_stop();
+  extern function void start_testcase();
+  extern function void stop_testcase();
+  extern function bit  is_testcase_running();
 
   extern function void update_exit_status();
   extern function void report();
@@ -167,6 +180,51 @@ endfunction
 */
 function bit svunit_testcase::is_running();
   return running;
+endfunction
+
+
+/*
+  Method: wait_for_testcase_start
+  Waits until the test case has started execution
+*/
+task svunit_testcase::wait_for_testcase_start();
+  wait(testcase_running == 1);
+endtask
+
+
+/*
+  Method: wait_for_testcase_stop
+  Waits until the test case has stopped execution
+*/
+task svunit_testcase::wait_for_testcase_stop();
+  wait(testcase_running == 0);
+endtask
+
+
+/*
+  Method: start_testcase
+  Changes the execution status of the test case to running
+*/
+function void svunit_testcase::start_testcase();
+  testcase_running = 1;
+endfunction
+
+
+/*
+  Method: stop_testcase
+  Changes the execution status of the test case to stopped
+*/
+function void svunit_testcase::stop_testcase();
+  testcase_running = 0;
+endfunction
+
+
+/*
+  Method: is_testcase_running
+  Returns the execution status of the test case
+*/
+function bit svunit_testcase::is_testcase_running();
+  return testcase_running;
 endfunction
 
 

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -40,10 +40,10 @@ class svunit_testcase extends svunit_base;
 
 
   /*
-    Variable: running
+    Variable: test_running
     1 is somewhere between setup and teardown, 0 otherwise
   */
-  local bit running = 0;
+  local bit test_running = 0;
   
   
   /*
@@ -64,9 +64,9 @@ class svunit_testcase extends svunit_base;
 
   extern function bit fail(string c, bit b, string s, string f, int l, string d = "");
 
-  extern function void start();
-  extern function void stop();
-  extern function bit  is_running();
+  extern function void start_test();
+  extern function void stop_test();
+  extern function bit  is_test_running();
   
   extern task wait_for_testcase_start();
   extern task wait_for_testcase_stop();
@@ -156,30 +156,30 @@ endfunction
 
 
 /*
-  Method: start
+  Method: start_test
   Changes the execution status of the test to running and increment the test count
 */
-function void svunit_testcase::start();
-  running = 1;
+function void svunit_testcase::start_test();
+  test_running = 1;
   test_count++;
 endfunction
 
 
 /*
-  Method: stop
+  Method: stop_test
   Changes the execution status of the test to stopped
 */
-function void svunit_testcase::stop();
-  running = 0;
+function void svunit_testcase::stop_test();
+  test_running = 0;
 endfunction
 
 
 /*
-  Method: is_running
+  Method: is_test_running
   Returns the execution status of the test
 */
-function bit svunit_testcase::is_running();
-  return running;
+function bit svunit_testcase::is_test_running();
+  return test_running;
 endfunction
 
 


### PR DESCRIPTION
Note that I added some methods into the svunit_testcase class to get this to work.  Since the svunit_testcase class seems to handle both testcases and individual tests, I ended up adding testcase related functions such as start_testcase() and stop_testcase() into the svunit_testcase class.  These new methods allow the SVUNIT_CLK_GEN macro to generate a clock that runs for the entire time the testcase (and all of the tests it contains) are active.

Unfortunately this meant that the original start() and stop() methods now had an ambiguous name.  In order to make things more clear, I renamed the original start() and stop() methods to start_test() and stop_test().  Hopefully this renaming is ok with you.  If not, then I would be happy to change them back or rename them to something else.