### PR TITLE
Framework tests fix for VCS compiler

### DIFF
--- a/bin/buildSVUnit
+++ b/bin/buildSVUnit
@@ -39,6 +39,7 @@ my $VERSION;
 my $version;
 my $outdir = ".";
 my @tests;
+my $mock;
 my $help;
 
 
@@ -51,6 +52,7 @@ sub usage() {
   print "Usage:  buildSVUnit [ -t <test> -h|--help ]\n\n";
   print "  -o|--out                 : output directory for tmp and simulation files\n";
   print "  -t|--test                : specifies a unit test to run (multiple can be given)\n";
+  print "  -m|--mock                : includes the uvm_mock_pkg to the final build file\n";
   print "  -h|--help                : prints this help screen\n";
   print "\n";
   exit 1;
@@ -170,6 +172,7 @@ sub getUnittests {
 
 GetOptions("o|out=s" => \$outdir,
            "t|test=s" => \@tests,
+           "m|mock" => \$mock,
            "h|help" => \$help
            ) or usage();
 
@@ -184,6 +187,9 @@ $FILELIST->print("+incdir+$cwd\n");
 $FILELIST->print("+incdir+$ENV{SVUNIT_INSTALL}/svunit_base\n");
 $FILELIST->print("+incdir+$ENV{SVUNIT_INSTALL}/svunit_base/uvm-mock\n");
 $FILELIST->print("$ENV{SVUNIT_INSTALL}/svunit_base/svunit_pkg.sv\n");
+if (defined $mock) {
+  $FILELIST->print("$ENV{SVUNIT_INSTALL}/svunit_base/uvm_mock/svunit_uvm_mock_pkg.sv\n");
+}
 
 getFilelists;
 buildTestsuite($pwd);

--- a/bin/buildSVUnit
+++ b/bin/buildSVUnit
@@ -188,7 +188,7 @@ $FILELIST->print("+incdir+$ENV{SVUNIT_INSTALL}/svunit_base\n");
 $FILELIST->print("+incdir+$ENV{SVUNIT_INSTALL}/svunit_base/uvm-mock\n");
 $FILELIST->print("$ENV{SVUNIT_INSTALL}/svunit_base/svunit_pkg.sv\n");
 if (defined $mock) {
-  $FILELIST->print("$ENV{SVUNIT_INSTALL}/svunit_base/uvm_mock/svunit_uvm_mock_pkg.sv\n");
+  $FILELIST->print("$ENV{SVUNIT_INSTALL}/svunit_base/uvm-mock/svunit_uvm_mock_pkg.sv\n");
 }
 
 getFilelists;

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -165,6 +165,11 @@ foreach (@tests) {
   $build_cmd .= " -t $_";
 }
 
+# include mock package for UVM compilation
+if (defined $uvm) {
+  $build_cmd .= " --mock";
+}
+
 # run!!
 if (system("$build_cmd")) {
   exit -1;

--- a/test/frmwrk_14/run
+++ b/test/frmwrk_14/run
@@ -2,14 +2,22 @@ NEWPATH=`echo $PATH | sed -e "s/svunit-code\/bin//"`
 export PATH=$NEWPATH
 export SVUNIT_INSTALL=
 
-csh run.csh
-if [ "$?" != "0" ]; then
-  exit 1
-fi
+source ../test_functions.bsh
 
-tcsh run.csh
-if [ "$?" != "0" ]; then
-  exit 1
-fi
+setup
+
+set_simulators
+
+for s in ${SVUNIT_SIMULATORS[@]}; do
+  csh run.csh $s
+  if [ "$?" != "0" ]; then
+    exit 1
+  fi
+
+  tcsh run.csh $s
+  if [ "$?" != "0" ]; then
+    exit 1
+  fi
+done
 
 exit 0

--- a/test/frmwrk_14/run.csh
+++ b/test/frmwrk_14/run.csh
@@ -10,7 +10,7 @@ rm -rf dut_unit_test.sv;
 create_unit_test.pl -overwrite -out dut_unit_test.sv dut.sv
 
 # build the framework
-runSVUnit -sim questa
+runSVUnit -s $1
 
 if ( ! -e run.log ) exit 1
 

--- a/test/frmwrk_3/test_unit_test.gold
+++ b/test/frmwrk_3/test_unit_test.gold
@@ -31,6 +31,7 @@ module test0_unit_test;
   task setup();
     svunit_ut.setup();
     /* Place Setup Code Here */
+
   endtask
 
 
@@ -41,6 +42,7 @@ module test0_unit_test;
   task teardown();
     svunit_ut.teardown();
     /* Place Teardown Code Here */
+
   endtask
 
 
@@ -60,10 +62,10 @@ module test0_unit_test;
   `SVUNIT_TESTS_BEGIN
 
 
+
   `SVUNIT_TESTS_END
 
 endmodule
-
 
 module test1_unit_test;
   import svunit_pkg::svunit_testcase;
@@ -95,6 +97,7 @@ module test1_unit_test;
   task setup();
     svunit_ut.setup();
     /* Place Setup Code Here */
+
   endtask
 
 
@@ -105,6 +108,7 @@ module test1_unit_test;
   task teardown();
     svunit_ut.teardown();
     /* Place Teardown Code Here */
+
   endtask
 
 
@@ -122,6 +126,7 @@ module test1_unit_test;
   //   `SVTEST_END
   //===================================
   `SVUNIT_TESTS_BEGIN
+
 
 
   `SVUNIT_TESTS_END

--- a/test/frmwrk_3/testsuite.gold
+++ b/test/frmwrk_3/testsuite.gold
@@ -3,7 +3,8 @@ module PWD_testsuite;
 
   string name = "PWD_ts";
   svunit_testsuite svunit_ts;
-
+  
+  
   //===================================
   // These are the unit tests that we
   // want included in this testsuite
@@ -35,5 +36,3 @@ module PWD_testsuite;
   endtask
 
 endmodule
-
-

--- a/test/sim_12/run
+++ b/test/sim_12/run
@@ -5,6 +5,12 @@ setup
 set_simulators
 
 for s in ${SVUNIT_SIMULATORS[@]}; do
+  if [[ "$s" -eq "vcs" ]]; then
+    echo "WARNING: VCS mixed language simulation requires multistage compilation."
+    echo "         Unfortunately, it has not been implemented yet."
+    echo "         Skipping the test..."
+    continue
+  fi
   runSVUnit -s $s -m vhdl.f
 
   expect_testrunner_pass run.log

--- a/test/sim_13/run
+++ b/test/sim_13/run
@@ -7,7 +7,7 @@ set_simulators
 for s in ${SVUNIT_SIMULATORS[@]}; do
   runSVUnit -s $s
 
-  expect_string "ERROR: \[50\]\[dut_ut\]: fail_if: svunit_timeout (at /scratch/user/njohnson/svunit-code/test/sim_13/./dut_unit_test.sv line:62)" run.log &&
+  expect_string "ERROR: \[50\]\[dut_ut\]: fail_if: svunit_timeout (at `pwd`/./dut_unit_test.sv line:62)" run.log &&
   expect_string "INFO:  \[99\]\[dut_ut\]: no_timeout::PASSED" run.log
 done
 

--- a/test/sim_4/clean
+++ b/test/sim_4/clean
@@ -1,3 +1,2 @@
 cleanSVUnit
-rm -f dut_unit_test.sv \
-      other.log
+rm -f other.log

--- a/test/sim_4/dut_unit_test.sv
+++ b/test/sim_4/dut_unit_test.sv
@@ -1,0 +1,66 @@
+`include "svunit_defines.svh"
+`include "dut.sv"
+
+module dut_unit_test;
+  import svunit_pkg::svunit_testcase;
+
+  string name = "dut_ut";
+  svunit_testcase svunit_ut;
+
+
+  //===================================
+  // This is the UUT that we're 
+  // running the Unit Tests on
+  //===================================
+  dut my_dut();
+
+
+  //===================================
+  // Build
+  //===================================
+  function void build();
+    svunit_ut = new(name);
+  endfunction
+
+
+  //===================================
+  // Setup for running the Unit Tests
+  //===================================
+  task setup();
+    svunit_ut.setup();
+    /* Place Setup Code Here */
+
+  endtask
+
+
+  //===================================
+  // Here we deconstruct anything we 
+  // need after running the Unit Tests
+  //===================================
+  task teardown();
+    svunit_ut.teardown();
+    /* Place Teardown Code Here */
+
+  endtask
+
+
+  //===================================
+  // All tests are defined between the
+  // SVUNIT_TESTS_BEGIN/END macros
+  //
+  // Each individual test must be
+  // defined between `SVTEST(_NAME_)
+  // `SVTEST_END
+  //
+  // i.e.
+  //   `SVTEST(mytest)
+  //     <test code>
+  //   `SVTEST_END
+  //===================================
+  `SVUNIT_TESTS_BEGIN
+
+    #(1);
+
+  `SVUNIT_TESTS_END
+
+endmodule

--- a/test/sim_4/run
+++ b/test/sim_4/run
@@ -5,7 +5,7 @@ setup
 set_simulators
 
 # remove and create the unit_test
-create_unit_test.pl -overwrite -out dut_unit_test.sv dut.sv
+# create_unit_test.pl -overwrite -out dut_unit_test.sv dut.sv
 
 for s in ${SVUNIT_SIMULATORS[@]}; do
   runSVUnit --sim $s --log other.log --define DIDLEY_SQUAT -d FIDDLE_FADDLE='"junk"'

--- a/test/util_clk_reset/run
+++ b/test/util_clk_reset/run
@@ -2,6 +2,10 @@ source ../test_functions.bsh
 
 setup
 
-runSVUnit -s questa
+set_simulators
+
+for s in ${SVUNIT_SIMULATORS[@]}; do
+  runSVUnit -s $s
+done
 
 expect_testrunner_pass run.log


### PR DESCRIPTION
Commit proposal for issue #46 

Short description  of changes
frmwrk_3 - some empty lines were added/removed to match test generator
frmwrk_14 - fixed to run with list of available simulators
util_clk_reset - fixed to run with list of available simulators
sim_4 - delay was added to the unit test to wait for DUT $display()
sim_12 - bypass test for VCS simulation
sim_13 - check error with full path (`pwd` usage)