### PR TITLE
Add UVM awareness to 'buildSVUnit' script

### DIFF
--- a/bin/buildSVUnit
+++ b/bin/buildSVUnit
@@ -9,9 +9,9 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,6 +39,7 @@ my $VERSION;
 my $version;
 my $outdir = ".";
 my @tests;
+my $uvm;
 my $help;
 
 
@@ -51,6 +52,7 @@ sub usage() {
   print "Usage:  buildSVUnit [ -t <test> -h|--help ]\n\n";
   print "  -o|--out                 : output directory for tmp and simulation files\n";
   print "  -t|--test                : specifies a unit test to run (multiple can be given)\n";
+  print "  -U|--uvm                 : build SVUnit with UVM\n";
   print "  -h|--help                : prints this help screen\n";
   print "\n";
   exit 1;
@@ -170,6 +172,7 @@ sub getUnittests {
 
 GetOptions("o|out=s" => \$outdir,
            "t|test=s" => \@tests,
+           "U|uvm" => \$uvm,
            "h|help" => \$help
            ) or usage();
 
@@ -182,8 +185,12 @@ $FILELIST = IO::File->new();
 $FILELIST->open(">$outdir/.svunit.f");
 $FILELIST->print("+incdir+$cwd\n");
 $FILELIST->print("+incdir+$ENV{SVUNIT_INSTALL}/svunit_base\n");
-$FILELIST->print("+incdir+$ENV{SVUNIT_INSTALL}/svunit_base/uvm-mock\n");
 $FILELIST->print("$ENV{SVUNIT_INSTALL}/svunit_base/svunit_pkg.sv\n");
+
+if ($uvm) {
+  $FILELIST->print("+incdir+$ENV{SVUNIT_INSTALL}/svunit_base/uvm-mock\n");
+  $FILELIST->print("$ENV{SVUNIT_INSTALL}/svunit_base/uvm-mock/svunit_uvm_mock_pkg.sv\n");
+}
 
 getFilelists;
 buildTestsuite($pwd);

--- a/bin/create_unit_test.pl
+++ b/bin/create_unit_test.pl
@@ -9,9 +9,9 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -112,7 +112,7 @@ sub CheckArgs() {
   }
 }
 
-  
+
 ##########################################################################
 # ValidArgs(): This checks to see if the arguments provided make sense.
 ##########################################################################
@@ -194,7 +194,7 @@ sub Main() {
     if (!$incomments) {
       # filter full /* */ comments
       $line =~ s|/\*.*?\*/||g;
-   
+
       # filter // comments
       $line =~ s|//.*||;
 
@@ -301,7 +301,6 @@ sub CreateUnitTest() {
   if (!$includes_already_printed) {
     print OUTFILE "`include \"svunit_defines.svh\"\n";
     if ($uvm_test) {
-      print OUTFILE "`include \"svunit_uvm_mock_pkg.sv\"\n";
       print OUTFILE "import uvm_pkg::*;\n";
     }
 
@@ -314,7 +313,7 @@ sub CreateUnitTest() {
   }
   if ($uvm_test) {
     print OUTFILE "  import svunit_uvm_mock_pkg::*;\n";
-  } 
+  }
   print OUTFILE "\n";
   if ($uvm_test) {
     CreateUvmClassForTest();
@@ -335,13 +334,13 @@ sub CreateUnitTest() {
       print OUTFILE "  $uvm_class_name my_$uut;\n\n\n";
     } else {
       print OUTFILE "  $uut my_$uut;\n\n\n";
-    }  
+    }
   } else {
       if ($uvm_test) {
         print OUTFILE " $uvm_class_name  my_$uut();\n\n\n";
       } else {
           print OUTFILE "  $uut my_$uut();\n\n\n";
-      }    
+      }
   }
   print OUTFILE "  //===================================\n";
   print OUTFILE "  // Build\n";
@@ -353,9 +352,9 @@ sub CreateUnitTest() {
     if ($uvm_test) {
       print OUTFILE "    my_$uut = $uvm_class_name\:\:type_id\:\:create(\"\"\, null);\n";
       print OUTFILE "\n    svunit_deactivate_uvm_component(my_$uut);\n";
-    } else { 
+    } else {
       print OUTFILE "    my_$uut = new(\/\* New arguments if needed \*\/);\n";
-    }  
+    }
   }
   print OUTFILE "  endfunction\n\n\n";
   print OUTFILE "  //===================================\n";
@@ -370,7 +369,7 @@ sub CreateUnitTest() {
     print OUTFILE "    // start the testing phase\n";
     print OUTFILE "    //-----------------------------\n";
     print OUTFILE "    svunit_uvm_test_start();\n\n\n\n";
-  }  
+  }
   print OUTFILE "  endtask\n\n\n";
   print OUTFILE "  //===================================\n";
   print OUTFILE "  // Here we deconstruct anything we \n";
@@ -383,11 +382,11 @@ sub CreateUnitTest() {
     print OUTFILE "    // terminate the testing phase \n";
     print OUTFILE "    //-----------------------------\n";
     print OUTFILE "    svunit_uvm_test_finish();\n\n";
-  }  
+  }
   print OUTFILE "    \/\* Place Teardown Code Here \*\/\n\n";
   if ($uvm_test) {
     print OUTFILE "    svunit_deactivate_uvm_component(my_$uut);\n";
-  }   
+  }
   print OUTFILE "  endtask\n\n\n";
   print OUTFILE "  //===================================\n";
   print OUTFILE "  // All tests are defined between the\n";
@@ -410,7 +409,7 @@ sub CreateUnitTest() {
 
 ##########################################################################
 # CreateUvmClassForTest(): This creates a wrapper to allow for uvm phase
-#                   connections. 
+#                   connections.
 ##########################################################################
 sub CreateUvmClassForTest(){
   print OUTFILE "class $uvm_class_name extends $uut;\n\n";
@@ -443,5 +442,5 @@ CheckArgs();
 if ( ValidArgs() == 0) {
   OpenFiles();
   Main();
-  CloseFiles(); 
+  CloseFiles();
 }

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -9,9 +9,9 @@
 #  to you under the Apache License, Version 2.0 (the
 #  "License"); you may not use this file except in compliance
 #  with the License.  You may obtain a copy of the License at
-#  
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-#  
+#
 #  Unless required by applicable law or agreed to in writing,
 #  software distributed under the License is distributed on an
 #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -164,6 +164,7 @@ my $build_cmd = "buildSVUnit -o $outdir";
 foreach (@tests) {
   $build_cmd .= " -t $_";
 }
+$build_cmd .= " --uvm" if $uvm;
 
 # run!!
 if (system("$build_cmd")) {

--- a/examples/uvm/simple_model/simple_model_unit_test.sv
+++ b/examples/uvm/simple_model/simple_model_unit_test.sv
@@ -1,5 +1,5 @@
 `include "svunit_defines.svh"
-`include "svunit_uvm_mock_pkg.sv"
+
 `include "simple_model.sv"
 import svunit_uvm_mock_pkg::*;
 
@@ -11,10 +11,10 @@ class simple_model_uvm_wrapper extends simple_model;
    // connect_phase().
    uvm_blocking_put_port #(simple_xaction) in_put_port;
    uvm_tlm_fifo #(simple_xaction)          in_put_fifo;
-   
+
    uvm_tlm_fifo #(simple_xaction)          out_get_fifo;
    uvm_blocking_get_port #(simple_xaction) out_get_port;
-   
+
    function new(string name = "simple_model_uvm_wrapper", uvm_component parent);
       super.new(name, parent);
       in_put_port = new("in_put_port", null);
@@ -29,7 +29,7 @@ class simple_model_uvm_wrapper extends simple_model;
    function void build_phase(uvm_phase phase);
       super.build_phase(phase);
       /* Place Build Code Here */
-      
+
    endfunction
 
    //==================================
@@ -37,17 +37,17 @@ class simple_model_uvm_wrapper extends simple_model;
    //=================================
    function void connect_phase(uvm_phase phase);
       super.connect_phase(phase);
-      
+
       /* Place Connection Code Here */
 
       // Connect the extra ports/FIFOs to the simple_model ports.
       get_port.connect(in_put_fifo.get_export);
       in_put_port.connect(in_put_fifo.put_export);
-      
+
       out_get_port.connect(out_get_fifo.get_export);
       put_port.connect(out_get_fifo.put_export);
    endfunction // connect_phase
-   
+
 endclass // simple_model_uvm_wrapper
 
 
@@ -59,7 +59,7 @@ module simple_model_unit_test;
 
 
    //===================================
-   // This is the UUT that we're 
+   // This is the UUT that we're
    // running the Unit Tests on
    //===================================
    simple_model_uvm_wrapper my_simple_model;
@@ -100,13 +100,13 @@ module simple_model_unit_test;
 
 
    //===================================
-   // Here we deconstruct anything we 
+   // Here we deconstruct anything we
    // need after running the Unit Tests
    //===================================
    task teardown();
       svunit_ut.teardown();
       //-----------------------------
-      // terminate the testing phase 
+      // terminate the testing phase
       //-----------------------------
       svunit_uvm_test_finish();
 
@@ -116,7 +116,7 @@ module simple_model_unit_test;
       // the next test.
       my_simple_model.out_get_fifo.flush();
       my_simple_model.in_put_fifo.flush();
-      
+
       svunit_deactivate_uvm_component(my_simple_model);
    endtask
 
@@ -135,7 +135,7 @@ module simple_model_unit_test;
    //   `SVTEST_END
    //===================================
    `SVUNIT_TESTS_BEGIN
-     
+
      //************************************************************
      // Test:
      //   get_port_not_null_test
@@ -161,13 +161,13 @@ module simple_model_unit_test;
      `SVTEST(get_in_port_active_test)
        begin
          simple_xaction tr = new();
- 
+
          my_simple_model.in_put_port.put(tr);
          #1;
          `FAIL_UNLESS(my_simple_model.in_put_fifo.is_empty());
        end
      `SVTEST_END
- 
+
       //************************************************************
       // Test:
       //   get_port_active_test
@@ -179,14 +179,14 @@ module simple_model_unit_test;
      `SVTEST(get_out_port_active_test)
        begin
          simple_xaction tr = new();
- 
+
          my_simple_model.in_put_port.put(tr);
          #1;
          `uvm_info("simple_model_unit_test", $psprintf("out_get_fifo empty : %0d", my_simple_model.out_get_fifo.is_empty()), UVM_NONE)
          `FAIL_IF(my_simple_model.out_get_fifo.is_empty());
        end
      `SVTEST_END
- 
+
      //************************************************************
      // Test:
      //   xformation_test
@@ -199,18 +199,18 @@ module simple_model_unit_test;
        begin
          simple_xaction in_tr = new();
          simple_xaction out_tr;
-      
+
          void'(in_tr.randomize() with { field == 2; });
          `FAIL_UNLESS(my_simple_model.out_get_fifo.is_empty());
-      
+
          my_simple_model.in_put_port.put(in_tr);
          my_simple_model.out_get_port.get(out_tr);
-      
+
          `FAIL_IF(in_tr.field != 2);
          `FAIL_IF(out_tr.field != 4);
        end
      `SVTEST_END
-     
+
      `SVUNIT_TESTS_END
 
 endmodule

--- a/examples/uvm/uvm_express/apb_coverage_agent_unit_test.sv
+++ b/examples/uvm/uvm_express/apb_coverage_agent_unit_test.sv
@@ -19,7 +19,6 @@
 //
 //###############################################################
 
-`include "svunit_uvm_mock_pkg.sv"
 `include "svunit_defines.svh"
 `include "apb_coverage_agent.sv"
 `include "apb_if.sv"
@@ -41,7 +40,7 @@ module apb_coverage_agent_unit_test;
   virtual apb_if.mstr bfm_mstr;
 
   //===================================
-  // This is the UUT that we're 
+  // This is the UUT that we're
   // running the Unit Tests on
   //===================================
   apb_coverage_agent my_apb_coverage_agent;
@@ -87,7 +86,7 @@ module apb_coverage_agent_unit_test;
 
 
   //===================================
-  // Here we deconstruct anything we 
+  // Here we deconstruct anything we
   // need after running the Unit Tests
   //===================================
   task teardown();

--- a/examples/uvm/uvm_express/apb_coverage_unit_test.sv
+++ b/examples/uvm/uvm_express/apb_coverage_unit_test.sv
@@ -19,7 +19,6 @@
 //
 //###############################################################
 
-`include "svunit_uvm_mock_pkg.sv"
 `include "svunit_defines.svh"
 `include "apb_coverage.sv"
 
@@ -32,7 +31,7 @@ module apb_coverage_unit_test;
 
 
   //===================================
-  // This is the UUT that we're 
+  // This is the UUT that we're
   // running the Unit Tests on
   //===================================
   apb_coverage my_apb_coverage;
@@ -72,7 +71,7 @@ module apb_coverage_unit_test;
 
 
   //===================================
-  // Here we deconstruct anything we 
+  // Here we deconstruct anything we
   // need after running the Unit Tests
   //===================================
   task teardown();
@@ -143,14 +142,14 @@ module apb_coverage_unit_test;
 
     a = apb_xaction::type_id::create();
     void'(a.randomize() with { addr == 'hfc;
-                               data == 0; 
+                               data == 0;
                                kind == WRITE;
                              });
 
     my_apb_coverage.write(a);
 
     `FAIL_IF(my_apb_coverage.cg.addr_max_cp.get_coverage() != 100);
- 
+
   `SVTEST_END
 
   //-------------------------------------
@@ -164,7 +163,7 @@ module apb_coverage_unit_test;
 
     a = apb_xaction::type_id::create();
     void'(a.randomize() with { addr == 1;
-                               data == 0; 
+                               data == 0;
                                kind == WRITE;
                              });
 
@@ -181,7 +180,7 @@ module apb_coverage_unit_test;
     end
 
     `FAIL_IF(my_apb_coverage.cg.addr_bins_cp.get_coverage() != 100);
- 
+
   `SVTEST_END
 
   //-------------------------------------
@@ -200,7 +199,7 @@ module apb_coverage_unit_test;
     my_apb_coverage.write(a);
 
     `FAIL_IF(my_apb_coverage.cg.data_max_cp.get_coverage() != 100);
- 
+
   `SVTEST_END
 
   //-------------------------------------
@@ -249,7 +248,7 @@ module apb_coverage_unit_test;
     my_apb_coverage.write(a);
 
     `FAIL_IF(my_apb_coverage.cg.kind_cp.get_coverage() != 100);
- 
+
   `SVTEST_END
 
 

--- a/examples/uvm/uvm_express/apb_mon_unit_test.sv
+++ b/examples/uvm/uvm_express/apb_mon_unit_test.sv
@@ -19,7 +19,6 @@
 //
 //###############################################################
 
-`include "svunit_uvm_mock_pkg.sv"
 `include "svunit_defines.svh"
 `include "apb_mon.sv"
 `include "apb_xaction.sv"
@@ -46,7 +45,7 @@ module apb_mon_unit_test;
   uvm_tlm_analysis_fifo #(apb_xaction) af;
 
   //===================================
-  // This is the UUT that we're 
+  // This is the UUT that we're
   // running the Unit Tests on
   //===================================
   apb_mon my_apb_mon;
@@ -97,7 +96,7 @@ module apb_mon_unit_test;
 
 
   //===================================
-  // Here we deconstruct anything we 
+  // Here we deconstruct anything we
   // need after running the Unit Tests
   //===================================
   task teardown();

--- a/examples/uvm/uvm_report_mock/uut_unit_test.sv
+++ b/examples/uvm/uvm_report_mock/uut_unit_test.sv
@@ -25,7 +25,6 @@
 
 import uvm_pkg::*;
 
-`include "svunit_uvm_mock_pkg.sv"
 `include "uut.sv"
 
 module uut_unit_test;
@@ -37,7 +36,7 @@ module uut_unit_test;
 
 
   //===================================
-  // This is the UUT that we're 
+  // This is the UUT that we're
   // running the Unit Tests on
   //===================================
   uut my_uut;
@@ -67,7 +66,7 @@ module uut_unit_test;
 
 
   //===================================
-  // Here we deconstruct anything we 
+  // Here we deconstruct anything we
   // need after running the Unit Tests
   //===================================
   task teardown();
@@ -140,9 +139,9 @@ module uut_unit_test;
 
   //--------------------------------------------
   // test: gt_100_is_a_warning
-  // desc: when 100 is passed in to 
+  // desc: when 100 is passed in to
   //       warn_arg_is_gt_100, we expect that
-  //       warning by first calling the 
+  //       warning by first calling the
   //       uvm_report_mock::expect_error().
   //--------------------------------------------
   `SVTEST(gt_100_is_a_warning)

--- a/test/mock_uvm_report/basic_unit_test.sv
+++ b/test/mock_uvm_report/basic_unit_test.sv
@@ -1,6 +1,5 @@
 import svunit_pkg::*;
 
-`include "svunit_uvm_mock_pkg.sv"
 import svunit_uvm_mock_pkg::*;
 
 `include "svunit_defines.svh"
@@ -18,7 +17,7 @@ module basic_unit_test;
 
 
   //===================================
-  // This is the UUT that we're 
+  // This is the UUT that we're
   // running the Unit Tests on
   //===================================
   basic my_basic;
@@ -46,7 +45,7 @@ module basic_unit_test;
 
 
   //===================================
-  // Here we deconstruct anything we 
+  // Here we deconstruct anything we
   // need after running the Unit Tests
   //===================================
   task teardown();
@@ -95,7 +94,7 @@ module basic_unit_test;
     my_basic.actual_fatal;
     uvm_report_mock::expect_fatal();
     uvm_report_mock::expect_error();
-    `FAIL_IF(uvm_report_mock::verify_complete()); 
+    `FAIL_IF(uvm_report_mock::verify_complete());
   `SVTEST_END
 
 
@@ -104,7 +103,7 @@ module basic_unit_test;
     my_basic.actual_fatal;
     uvm_report_mock::expect_error("my_basic", "error message");
     uvm_report_mock::expect_fatal("my_basic", "fatal message");
-    `FAIL_IF(!uvm_report_mock::verify_complete()); 
+    `FAIL_IF(!uvm_report_mock::verify_complete());
   `SVTEST_END
 
 
@@ -123,7 +122,7 @@ module basic_unit_test;
     dump_exp = { dump_exp , "     ACTUAL   =>      UVM_ERROR                     \"\" \"\"\n" };
 
     dump_act = uvm_report_mock::dump();
- 
+
     `FAIL_IF(dump_act != dump_exp);
   `SVTEST_END
 
@@ -136,7 +135,7 @@ module basic_unit_test;
     dump_exp = { dump_exp , "     ACTUAL   =>    UVM_WARNING            \"ID actual\" \"MSG actual\"\n" };
 
     dump_act = uvm_report_mock::dump();
- 
+
     `FAIL_IF(dump_act != dump_exp);
   `SVTEST_END
 
@@ -147,9 +146,9 @@ module basic_unit_test;
     dump_exp = dump_header();
     dump_exp = { dump_exp , "0:   EXPECTED =>    UVM_WARNING          \"ID expected\" \"MSG expected\"\n" };
     dump_exp = { dump_exp , "     ACTUAL   =>    UVM_WARNING            \"ID actual\" \"MSG actual\"\n" };
- 
+
     dump_act = uvm_report_mock::dump();
- 
+
     `FAIL_IF(dump_act != dump_exp);
   `SVTEST_END
 
@@ -164,9 +163,9 @@ module basic_unit_test;
     dump_exp = { dump_exp , "     ACTUAL   =>    UVM_WARNING              \"ID act0\" \"MSG act0\"\n" };
     dump_exp = { dump_exp , "1:   EXPECTED =>      UVM_ERROR              \"ID exp1\" \"MSG exp1\"\n" };
     dump_exp = { dump_exp , "     ACTUAL   =>      UVM_ERROR              \"ID act1\" \"MSG act1\"\n" };
- 
+
     dump_act = uvm_report_mock::dump();
- 
+
     `FAIL_IF(dump_act != dump_exp);
   `SVTEST_END
 
@@ -176,7 +175,7 @@ module basic_unit_test;
     dump_exp = dump_header();
     dump_exp = { dump_exp , "0:   EXPECTED =>    UVM_WARNING              \"ID exp0\" \"MSG exp0\"\n" };
     dump_exp = { dump_exp , "     ACTUAL   =>  None reported                        \n" };
- 
+
     dump_act = uvm_report_mock::dump();
 
     `FAIL_IF(dump_act != dump_exp);
@@ -188,7 +187,7 @@ module basic_unit_test;
     dump_exp = dump_header();
     dump_exp = { dump_exp , "0:   EXPECTED =>  None reported                        \n" };
     dump_exp = { dump_exp , "     ACTUAL   =>      UVM_FATAL              \"ID exp0\" \"MSG exp0\"\n" };
- 
+
     dump_act = uvm_report_mock::dump();
 
     `FAIL_IF(dump_act != dump_exp);
@@ -200,7 +199,7 @@ module basic_unit_test;
     dump_exp = dump_header();
     dump_exp = { dump_exp , "0:   EXPECTED =>  None reported                        \n" };
     dump_exp = { dump_exp , "     ACTUAL   =>      UVM_FATAL \"ID exp0jfl sj ls jsl\" \"MSG exp0\"\n" };
- 
+
     dump_act = uvm_report_mock::dump();
 
     `FAIL_IF(dump_act != dump_exp);
@@ -212,7 +211,7 @@ module basic_unit_test;
     dump_exp = dump_header();
     dump_exp = { dump_exp , "0:   EXPECTED =>      UVM_FATAL \"ID exp0jfl sj ls jsl\" \"*\"\n" };
     dump_exp = { dump_exp , "     ACTUAL   =>  None reported                        \n" };
- 
+
     dump_act = uvm_report_mock::dump();
 
     `FAIL_IF(dump_act != dump_exp);
@@ -220,7 +219,7 @@ module basic_unit_test;
 
   `SVTEST(info_are_ignored)
     uvm_report_info("", "");
-    `FAIL_IF(!uvm_report_mock::verify_complete()); 
+    `FAIL_IF(!uvm_report_mock::verify_complete());
   `SVTEST_END
 
 

--- a/test/mock_uvm_report_ius/basic_unit_test.sv
+++ b/test/mock_uvm_report_ius/basic_unit_test.sv
@@ -1,6 +1,5 @@
 import svunit_pkg::*;
 
-`include "svunit_uvm_mock_pkg.sv"
 import svunit_uvm_mock_pkg::*;
 
 `include "svunit_defines.svh"

--- a/test/mock_uvm_report_ius_uvm1.2/basic_unit_test.sv
+++ b/test/mock_uvm_report_ius_uvm1.2/basic_unit_test.sv
@@ -1,6 +1,5 @@
 import svunit_pkg::*;
 
-`include "svunit_uvm_mock_pkg.sv"
 import svunit_uvm_mock_pkg::*;
 
 `include "svunit_defines.svh"


### PR DESCRIPTION
Building 'svunit_uvm_mock_pkg' is now handled by the build script, so no
more need to include it in unit tests. The examples, the tests and the
'create_unit_test.pl' script have been patched accordingly.