### PR TITLE
Usage of standard conformant $sformatf

### DIFF
--- a/examples/uvm/simple_model/simple_model_unit_test.sv
+++ b/examples/uvm/simple_model/simple_model_unit_test.sv
@@ -182,7 +182,7 @@ module simple_model_unit_test;
 
          my_simple_model.in_put_port.put(tr);
          #1;
-         `uvm_info("simple_model_unit_test", $psprintf("out_get_fifo empty : %0d", my_simple_model.out_get_fifo.is_empty()), UVM_NONE)
+         `uvm_info("simple_model_unit_test", $sformatf("out_get_fifo empty : %0d", my_simple_model.out_get_fifo.is_empty()), UVM_NONE)
          `FAIL_IF(my_simple_model.out_get_fifo.is_empty());
        end
      `SVTEST_END

--- a/test/sim_3/dut_unit_test.sv
+++ b/test/sim_3/dut_unit_test.sv
@@ -96,7 +96,7 @@ module dut_unit_test;
     `SVTEST(seventh_test)
       static int bozo = 4;
       static string gum = "gum is wrong";
-      `FAIL_IF_LOG(bozo != 2, $psprintf("%s %0d", gum, bozo));
+      `FAIL_IF_LOG(bozo != 2, $sformatf("%s %0d", gum, bozo));
     `SVTEST_END
 
     // verify FAIL_IF_EQUAL works with ternary operator (should pass)


### PR DESCRIPTION
Hi Neil,

I am trying to port SVunit to use the Xilinx Vivado simulator. I found, that Vivado doesn't support  `$psprintf`. I replaced it by its LRM counterpart.

Note: I only have Vivado and cannot check, that the other simulators work as expected.

Tobias