### PR TITLE
Add Setup.zsh

### DIFF
--- a/Setup.zsh
+++ b/Setup.zsh
@@ -1,0 +1,27 @@
+#!/usr/bin/zsh
+
+############################################################################
+#
+#  Copyright 2021 The SVUnit Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+############################################################################
+
+export SVUNIT_INSTALL=`pwd`
+
+case ":$PATH:" in
+	*":$SVUNIT_INSTALL:"*) :;; 
+	*) PATH="${SVUNIT_INSTALL}:${PATH}";;
+esac
+


### PR DESCRIPTION
I just added a simple setup script comparable to the `bash` or `csh` ones that are already there, since I (and many others) use `zsh` as their shell.

It should only append to `$PATH` if it hasn't already.