### PR TITLE
Initial color support

### DIFF
--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -192,4 +192,9 @@ if (system("$build_cmd")) {
 }
 print $cmd . "\n";
 system("$cmd");
+
+# Filter out ANSI color characters from log file
+# See here: https://superuser.com/questions/380772/removing-ansi-color-codes-from-text-stream
+system("sed -i 's/\x1b\[[0-9;]*m//g' $logfile");
+
 system("svunit_user_feedback.pl")

--- a/svunit_base/svunit_testsuite.sv
+++ b/svunit_base/svunit_testsuite.sv
@@ -38,6 +38,12 @@ class svunit_testsuite extends svunit_base;
 
   extern function void report();
 
+  /*
+    Private methods
+  */
+  extern function void print_color_start(string success_str);
+  extern function void print_color_end();
+
 endclass
 
 
@@ -98,10 +104,23 @@ function void svunit_testsuite::report();
     success_str = "FAILED";
     success = FAIL;
   end
-
+  
+  print_color_start(success_str);
   `LF;
   `INFO($sformatf("%0s (%0d of %0d testcases passing)",
     success_str,
     pass_cnt,
     list_of_testcases.size()));
+  print_color_end();
+endfunction
+
+function void svunit_testsuite::print_color_start(string success_str);
+  if (success_str == "PASSED")
+    $write("%c[1;34m",27); // Green
+  else
+	  $write("%c[1;31m",27); // Red
+endfunction
+
+function void svunit_testsuite::print_color_end();
+  $write("%c[0m",27); 
 endfunction

--- a/svunit_base/svunit_testsuite.sv
+++ b/svunit_base/svunit_testsuite.sv
@@ -116,9 +116,9 @@ endfunction
 
 function void svunit_testsuite::print_color_start(string success_str);
   if (success_str == "PASSED")
-    $write("%c[1;34m",27); // Green
+    $write("%c[1;32m", 27); // Green
   else
-	  $write("%c[1;31m",27); // Red
+    $write("%c[1;31m", 27); // Red
 endfunction
 
 function void svunit_testsuite::print_color_end();


### PR DESCRIPTION
For issue #103 

Adds color support for pass and fail strings. Green for pass, red for fail. Also has a regex ran with `sed` at the end of `runSVUnit` that removes the ANSI color coding from `run.log` so that it remains readable.

Below are examples of me running the `clk_and_reset` example with it passing and failing.

![image](https://user-images.githubusercontent.com/8103545/106552684-9c1a3000-64cc-11eb-819a-71f61b36f000.png)

![image](https://user-images.githubusercontent.com/8103545/106552730-b2c08700-64cc-11eb-9952-5b4245d0fc82.png)
