### PR TITLE
`FAIL_* macros in function

### DIFF
--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -16,85 +16,89 @@
 //
 //###########################################################################
 
+`ifndef __FAIL_FREEZE
+`define __FAIL_FREEZE svunit_pkg::current_tc.give_up();
+`endif
+
 /*
   Assertion Macros
 */
 `ifndef FAIL_IF
-`define FAIL_IF(exp) \
+`define FAIL_IF(exp,cmd=`__FAIL_FREEZE) \
   begin \
     if (svunit_pkg::current_tc.fail(`"fail_if`", (exp), `"exp`", `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif
 
 `ifndef FAIL_IF_LOG
-`define FAIL_IF_LOG(exp,msg) \
+`define FAIL_IF_LOG(exp,msg,cmd=`__FAIL_FREEZE) \
   begin \
     if (svunit_pkg::current_tc.fail(`"fail_if`", (exp), `"exp`", `__FILE__, `__LINE__, msg)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif
 
 `ifndef FAIL_IF_EQUAL
-`define FAIL_IF_EQUAL(a,b) \
+`define FAIL_IF_EQUAL(a,b,cmd=`__FAIL_FREEZE) \
   begin \
     if (svunit_pkg::current_tc.fail(`"fail_if_equal`", ((a)===(b)), `"(a) === (b)`", `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif
 
 `ifndef FAIL_UNLESS
-`define FAIL_UNLESS(exp) \
+`define FAIL_UNLESS(exp,cmd=`__FAIL_FREEZE) \
   begin \
     if (svunit_pkg::current_tc.fail(`"fail_unless`", !(exp), `"exp`", `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif
 
 `ifndef FAIL_UNLESS_LOG
-`define FAIL_UNLESS_LOG(exp,msg) \
+`define FAIL_UNLESS_LOG(exp,msg,cmd=`__FAIL_FREEZE) \
   begin \
     if (svunit_pkg::current_tc.fail(`"fail_unless`", !(exp), `"exp`", `__FILE__, `__LINE__, msg)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif
 
 `ifndef FAIL_UNLESS_EQUAL
-`define FAIL_UNLESS_EQUAL(a,b) \
+`define FAIL_UNLESS_EQUAL(a,b,cmd=`__FAIL_FREEZE) \
   begin \
     if (svunit_pkg::current_tc.fail(`"fail_unless_equal`", ((a)!==(b)), `"(a) !== (b)`", `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif
 
 `ifndef FAIL_IF_STR_EQUAL
-`define FAIL_IF_STR_EQUAL(a,b) \
+`define FAIL_IF_STR_EQUAL(a,b,cmd=`__FAIL_FREEZE) \
   begin \
     string stra; \
     string strb; \
     stra = a; \
     strb = b; \
     if (svunit_pkg::current_tc.fail(`"fail_if_str_equal`", stra.compare(strb)==0, $sformatf(`"\"%s\" == \"%s\"`",stra,strb), `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif
 
 `ifndef FAIL_UNLESS_STR_EQUAL
-`define FAIL_UNLESS_STR_EQUAL(a,b) \
+`define FAIL_UNLESS_STR_EQUAL(a,b,cmd=`__FAIL_FREEZE) \
   begin \
     string stra; \
     string strb; \
     stra = a; \
     strb = b; \
     if (svunit_pkg::current_tc.fail(`"fail_unless_str_equal`", stra.compare(strb)!=0, $sformatf(`"\"%s\" != \"%s\"`",stra,strb), `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin cmd end \
     end \
   end
 `endif

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -30,6 +30,13 @@ class svunit_testcase extends svunit_base;
 
 
   /*
+    uint: fail_count
+    Counter for number of fail
+  */
+  local int unsigned fail_count = 0;
+
+
+  /*
     uint: error_count
     Counter for number of errors
   */
@@ -110,7 +117,7 @@ endtask
   Returns the error count
 */
 function integer svunit_testcase::get_error_count();
-  return error_count;
+  return fail_count;
 endfunction
 
 
@@ -142,7 +149,7 @@ endtask
 function bit svunit_testcase::fail(string c, logic b, string s, string f, int l, string d = "");
   string _d;
   if (b !== 0) begin
-    error_count++;
+    fail_count++;
     if (d != "") begin
       $sformat(_d, "[ %s ] ", d);
     end
@@ -189,6 +196,10 @@ endfunction
   Updates the results of this testcase
 */
 function void svunit_testcase::update_exit_status();
+  if (fail_count != 0)
+    error_count++;
+  fail_count = 0;
+
   if (error_count == 0)
     success = PASS;
   else

--- a/test/sim_14/dut.sv
+++ b/test/sim_14/dut.sv
@@ -1,0 +1,2 @@
+interface dut;
+endinterface

--- a/test/sim_14/dut_unit_test.sv
+++ b/test/sim_14/dut_unit_test.sv
@@ -1,0 +1,79 @@
+`include "svunit_defines.svh"
+`include "dut.sv"
+
+import svunit_pkg::*;
+
+module dut_unit_test;
+  string name = "dut_ut";
+  svunit_testcase svunit_ut;
+
+
+  //===================================
+  // This is the UUT that we're
+  // running the Unit Tests on
+  //===================================
+  dut my_dut();
+
+
+  //===================================
+  // Build
+  //===================================
+  function void build();
+    svunit_ut = new(name);
+  endfunction
+
+
+  //===================================
+  // Setup for running the Unit Tests
+  //===================================
+  task setup();
+    svunit_ut.setup();
+    /* Place Setup Code Here */
+  endtask
+
+
+  //===================================
+  // Here we deconstruct anything we
+  // need after running the Unit Tests
+  //===================================
+  task teardown();
+    svunit_ut.teardown();
+    /* Place Teardown Code Here */
+  endtask
+
+
+  function void fail_in_function();
+    `FAIL_IF(1, return;)
+    `FAIL_IF_LOG(1, "This shouldn't be never call", begin end)
+  endfunction
+
+  //===================================
+  // All tests are defined between the
+  // SVUNIT_TESTS_BEGIN/END macros
+  //
+  // Each individual test must be
+  // defined between `SVTEST(_NAME_)
+  // `SVTEST_END
+  //
+  // i.e.
+  //   `SVTEST(mytest)
+  //     <test code>
+  //   `SVTEST_END
+  //===================================
+  `SVUNIT_TESTS_BEGIN
+    // this should have the "running" and "pass" logged
+    `SVTEST(function_fail)
+
+      fail_in_function();
+
+      `FAIL_IF(1)
+      `FAIL_IF_LOG(1, "This shouldn't be never call")
+    `SVTEST_END
+
+    `SVTEST(no_error)
+    `SVTEST_END
+
+  `SVUNIT_TESTS_END
+
+
+endmodule

--- a/test/sim_14/svunit.f
+++ b/test/sim_14/svunit.f
@@ -1,0 +1,1 @@
++define+SVUNIT_TIMEOUT=50

--- a/test/test_sim.py
+++ b/test/test_sim.py
@@ -186,6 +186,14 @@ def test_sim_13(datafiles, simulator):
         expect_string(br"ERROR: \[50\]\[dut_ut\]: fail_if: svunit_timeout (at `pwd`/./dut_unit_test.sv line:62)", 'run.log')
         expect_string(br"INFO:  \[99\]\[dut_ut\]: no_timeout::PASSED", 'run.log')
 
+@all_files_in_dir('sim_14')
+@all_available_simulators()
+def test_sim_14(datafiles, simulator):
+    with datafiles.as_cwd():
+        subprocess.check_call(['runSVUnit', '-s', simulator])
+
+        expect_string(br"ERROR: \[0\]\[dut_ut\]: fail_if: 1 \(at *./dut_unit_test.sv line:46\)", 'run.log')
+        expect_string(br"ERROR: \[0\]\[dut_ut\]: fail_if: 1 \(at *./dut_unit_test.sv line:69\)", 'run.log')
 
 @all_files_in_dir('fail_macros')
 @all_available_simulators()


### PR DESCRIPTION
As requested in #115 move commit with _FAIL* macro in function support_ to separate PR

Until now FAIL_* macros always called `give_up` task so macros could not
be use in function. Now this call is optional due to use of macros
argument.
To use FAIL_* macros in function use `return;` or `begin end` as last argument of macro.

Because there can be more then one FAIL_IF call without bloking svtest
with give_up also some updates to error_count was needed.

Comment from https://github.com/svunit/svunit/pull/115#issuecomment-878985660
> The root cause of this change is to use FAIL_* macros in the function body. Since macros call give_up task we can't do right now.
> Unfortunately simply removing this call from macros will ruin most current tests (test will not hang after the first ERROR), therefore the solution with code block. With this approach for example we can implement some bus monitors (e.g. axi) with transaction callback which are not related with a single svtest and are reusable.
> Of course callbecks can be tasks but functions in this case are more appropriate. 
> Also this approach seems more user friendly to me since you can just write: FAIL_IF(exp, return;) in function and for example you don't have to start new process which will be waiting for event with data from callback.

