### PR TITLE
Param module test

### DIFF
--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -130,10 +130,44 @@
 
 
 /*
+  Macro: `SVUNIT_LAUNCHER_DEFINE
+  Define extension of launcher wrapper for unit test
+*/
+`define SVUNIT_LAUNCHER_DEFINE(_UT_) \
+  class svunit_testcase_launcher_extension extends \
+        svunit_pkg::svunit_testcase_launcher; \
+    function void wrp_build(); \
+      svunit_pkg::current_tc = _UT_; \
+      build(); \
+      ut = _UT_; \
+    endfunction \
+    task wrp_setup(); \
+      setup(); \
+    endtask \
+    task wrp_teardown(); \
+      teardown(); \
+    endtask \
+    task automatic wrp_run(); \
+      run(); \
+    endtask \
+  endclass
+
+
+/*
+  Macro: `SVUNIT_LAUNCHER_INST
+  Instance of launcher
+*/
+`define SVUNIT_LAUNCHER_INST \
+  svunit_testcase_launcher_extension __launcher_inst = new();
+
+
+/*
   Macro: `SVUNIT_TESTS_BEGIN
   START a block of unit tests
 */
 `define SVUNIT_TESTS_BEGIN \
+  `SVUNIT_LAUNCHER_DEFINE(svunit_ut) \
+  `SVUNIT_LAUNCHER_INST \
   task automatic run(); \
     `INFO("RUNNING");
 
@@ -218,3 +252,33 @@ end \
                 wait( svunit_ut.is_running() ); \
         end \
     end
+
+
+/*
+  Macro: `SVUNIT_UT_PARAM_WRP
+  Use this macro at begin of wrapper with your parameterized unit tests modules
+  Internal infrastructure will be created
+*/
+`define SVUNIT_UT_PARAM_WRP(_name_ = "wrapper_with_parameterized_unit_tests") \
+  svunit_pkg::svunit_testcase_wrp svunit_ut = new(_name_); \
+  function void build(); \
+    svunit_ut.build(); \
+  endfunction \
+  task setup(); \
+    svunit_ut.setup(); \
+  endtask \
+  task teardown(); \
+    svunit_ut.teardown(); \
+  endtask \
+  task automatic run(); \
+    svunit_ut.run(); \
+  endtask
+
+
+/*
+ Macro: `SVUNIT_UT_PARAM
+ Add instance of parameterized unit test in wrapper layer
+*/
+`define SVUNIT_UT_PARAM(unit_test_module_inst) \
+  initial svunit_ut.add_launcher_inst(unit_test_module_inst.__launcher_inst);
+

--- a/svunit_base/svunit_pkg.sv
+++ b/svunit_base/svunit_pkg.sv
@@ -26,10 +26,13 @@ package svunit_pkg;
   const string svunit_version = "For SVUnit Version info, see: $SVUNIT_INSTALL/VERSION.txt";
 `endif
 
+  typedef class svunit_testcase;
+
   `include "svunit_types.svh"
   `include "svunit_base.sv"
+  `include "svunit_globals.svh"
   `include "svunit_testcase.sv"
+  `include "svunit_testcase_wrp.sv"
   `include "svunit_testsuite.sv"
   `include "svunit_testrunner.sv"
-  `include "svunit_globals.svh"
 endpackage

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -33,7 +33,7 @@ class svunit_testcase extends svunit_base;
     uint: error_count
     Counter for number of errors
   */
-  local int unsigned error_count = 0;
+  protected int unsigned error_count = 0;
 
 
   /*

--- a/svunit_base/svunit_testcase_wrp.sv
+++ b/svunit_base/svunit_testcase_wrp.sv
@@ -1,0 +1,48 @@
+
+/**
+ * Class: svunit_testcase_launcher
+ *
+ * Base class for launchers wrapper
+ */
+virtual class svunit_testcase_launcher;
+  svunit_pkg::svunit_testcase ut;
+  pure virtual function void wrp_build();
+  pure virtual task wrp_setup();
+  pure virtual task wrp_teardown();
+  pure virtual task automatic wrp_run();
+endclass
+
+
+/**
+ * Class: svunit_testcase_wrp
+ *
+ * Wrapper for testcases - wraps svunit_testcase methods with call on children
+ */
+class svunit_testcase_wrp extends svunit_pkg::svunit_testcase;
+  svunit_testcase_launcher launcher[$];
+
+  function new(string name);
+    super.new(name);
+  endfunction
+
+  function void build();
+    foreach(launcher[i]) begin
+      svunit_pkg::current_tc = launcher[i].ut;
+      launcher[i].wrp_build();
+    end
+  endfunction
+
+  task automatic run();
+    foreach(launcher[i]) begin
+      launcher[i].wrp_run();
+      launcher[i].ut.report();
+      error_count += launcher[i].ut.get_error_count();
+    end
+    update_exit_status();
+  endtask
+
+  function void add_launcher_inst(svunit_testcase_launcher inst);
+    launcher.push_back(inst);
+  endfunction
+
+endclass

--- a/svunit_base/svunit_testsuite.sv
+++ b/svunit_base/svunit_testsuite.sv
@@ -72,8 +72,15 @@ endfunction
     svunit - unit test to add to the list of unit tests
 */
 function void svunit_testsuite::add_testcase(svunit_testcase svunit);
+  svunit_testcase_wrp wrp;
   `INFO($sformatf("Registering Unit Test Case %s", svunit.get_name()));
-  list_of_testcases.push_back(svunit);
+  if ($cast(wrp, svunit)) begin
+    foreach(wrp.launcher[i]) begin
+      list_of_testcases.push_back(wrp.launcher[i].ut);
+    end
+  end else begin
+    list_of_testcases.push_back(svunit);
+  end
 endfunction
 
 

--- a/test/sim_15/dut.sv
+++ b/test/sim_15/dut.sv
@@ -1,0 +1,15 @@
+module dut #(
+    parameter int A = 0,
+    parameter type T = int,
+    parameter T V = '1
+);
+
+    function void print();
+        $display("print from param dut %m");
+        $display("  parameter A: %0d", A);
+        $display("  parameter $bits(T): %0d", $bits(T));
+        $display("  parameter V: %h", V);
+    endfunction
+
+
+endmodule

--- a/test/sim_15/dut_unit_test.sv
+++ b/test/sim_15/dut_unit_test.sv
@@ -1,0 +1,91 @@
+`include "svunit_defines.svh"
+`include "dut.sv"
+
+import svunit_pkg::*;
+
+module parameter_unit_test;
+  `SVUNIT_UT_PARAM_WRP("parameter_ut")
+
+  base_ut #(.name("dut_1_BE"), .A(1), .V('hBE)) ut_1_BE();
+  `SVUNIT_UT_PARAM(ut_1_BE)
+
+  base_ut #(.name("dut_2_CAFE"), .A(2), .V('hCAFE)) ut_2_CAFE();
+  `SVUNIT_UT_PARAM(ut_2_CAFE)
+
+  for(genvar i = 1; i <= 8; ++i) begin : inst
+    base_ut #(.name($sformatf("gen_%0d", i)), .A(i), .V(1<<i)) ut_gen();
+    `SVUNIT_UT_PARAM(ut_gen)
+  end
+
+endmodule
+
+
+module base_ut;
+  parameter string name = "dut_ut";
+  svunit_testcase svunit_ut;
+
+  parameter int A = 1;
+  parameter type T = bit[(8*A)-1:0];
+  parameter T V = '1;
+
+
+  //===================================
+  // This is the UUT that we're
+  // running the Unit Tests on
+  //===================================
+  dut #(A, T, V) my_dut();
+
+
+  //===================================
+  // Build
+  //===================================
+  function void build();
+    svunit_ut = new(name);
+  endfunction
+
+
+  //===================================
+  // Setup for running the Unit Tests
+  //===================================
+  task setup();
+    svunit_ut.setup();
+    /* Place Setup Code Here */
+  endtask
+
+
+  //===================================
+  // Here we deconstruct anything we
+  // need after running the Unit Tests
+  //===================================
+  task teardown();
+    svunit_ut.teardown();
+    /* Place Teardown Code Here */
+  endtask
+
+
+  //===================================
+  // All tests are defined between the
+  // SVUNIT_TESTS_BEGIN/END macros
+  //
+  // Each individual test must be
+  // defined between `SVTEST(_NAME_)
+  // `SVTEST_END
+  //
+  // i.e.
+  //   `SVTEST(mytest)
+  //     <test code>
+  //   `SVTEST_END
+  //===================================
+  `SVUNIT_TESTS_BEGIN
+    // this should have the "running" and "pass" logged
+    `SVTEST(print)
+      my_dut.print();
+    `SVTEST_END
+    `SVTEST(fail_for_param_value)
+      `FAIL_IF(A==1)
+    `SVTEST_END
+
+  `SVUNIT_TESTS_END
+
+
+endmodule

--- a/test/sim_15/svunit.f
+++ b/test/sim_15/svunit.f
@@ -1,0 +1,1 @@
++define+SVUNIT_TIMEOUT=50

--- a/test/test_sim.py
+++ b/test/test_sim.py
@@ -187,6 +187,20 @@ def test_sim_13(datafiles, simulator):
         expect_string(br"INFO:  \[99\]\[dut_ut\]: no_timeout::PASSED", 'run.log')
 
 
+@all_files_in_dir('sim_15')
+@all_available_simulators()
+def test_sim_15(datafiles, simulator):
+    with datafiles.as_cwd():
+        subprocess.check_call(['runSVUnit', '-s', simulator])
+
+        expect_string(br"print from param dut testrunner\.__ts\.parameter_ut\.ut_1_BE\.my_dut\.print", 'run.log')
+        expect_string(br"print from param dut testrunner\.__ts\.parameter_ut\.ut_2_CAFE\.my_dut\.print", 'run.log')
+        for i in range(1,8):
+            expect_string(br"print from param dut testrunner\.__ts\.parameter_ut\.inst\[%d\]\.ut_gen\.my_dut\.print" % i, 'run.log')
+            expect_string(br"parameter \$bits\(T\): %d" % (i*8), 'run.log')
+        expect_string(br"INFO:  \[0\]\[__ts\]: FAILED \(8 of 10 testcases passing\)", 'run.log')
+
+
 @all_files_in_dir('fail_macros')
 @all_available_simulators()
 def test_fail_macros(datafiles, simulator):


### PR DESCRIPTION
Hi

With this change user don't have to create separate unit tests for each set of parameters for parameterized module.
E.g. if we want to test module with various set of parameters it is enough to create standard SVUnit unit test with duts parameters export to unit test interface. Next thing would be create unit test wrapper with instances of parameterized unit test(s) with help of SVUNIT_UT_PARAM_WRP and SVUNIT_UT_PARAM macros. That's it. 
For example please check test/sim_15/dut_unit_test.sv

Please review
Thanks
Maciej