### PR TITLE
Printer singleton

### DIFF
--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -108,7 +108,7 @@
     msg - string to display
 */
 `define INFO(msg) \
-  $display("INFO:  [%0t][%0s]: %s", $time, name, msg)
+  svunit_pkg::svunit_printer::info(name, msg)
 
 
 /*
@@ -119,14 +119,15 @@
     msg - string to display
 */
 `define ERROR(msg) \
-  $display("ERROR: [%0t][%0s]: %s", $time, name, msg)
+  svunit_pkg::svunit_printer::error(name, msg)
 
 
 /*
   Macro: `LF
   Displays a blank line in log file
 */
-`define LF $display("");
+`define LF \
+  svunit_pkg::svunit_printer::lf()
 
 
 /*

--- a/svunit_base/svunit_pkg.sv
+++ b/svunit_base/svunit_pkg.sv
@@ -27,6 +27,7 @@ package svunit_pkg;
 `endif
 
   `include "svunit_types.svh"
+  `include "svunit_printer.svh"
   `include "svunit_base.sv"
   `include "svunit_testcase.sv"
   `include "svunit_testsuite.sv"

--- a/svunit_base/svunit_printer.svh
+++ b/svunit_base/svunit_printer.svh
@@ -1,0 +1,89 @@
+
+
+/*
+  Class: svunit_printer
+  Singleton object with default info and error display implementation
+ */
+class svunit_printer;
+
+  /*
+    default printer
+  */
+  class default_printer;
+    virtual function void info(string name, string msg);
+      $display("INFO:  [%0t][%0s]: %s", $time, name, msg);
+    endfunction
+    virtual function void error(string name, string msg);
+      $display("ERROR: [%0t][%0s]: %s", $time, name, msg);
+    endfunction
+    virtual function void lf();
+      $display("");
+    endfunction
+  endclass
+
+  typedef svunit_printer this_type;
+  local static this_type _this;
+  local default_printer _impl;
+
+  local function new();
+    default_printer default_impl = new();
+    _impl = default_impl;
+  endfunction
+
+  static function this_type get();
+    if(_this == null)
+        _this = new();
+    return _this;
+  endfunction
+
+  /*
+    Method: set_implementation
+    Overrides current printer implementation
+
+    Parameters:
+      impl - new printer implementation extended from default_printer
+  */
+  function void set_implementation(default_printer impl);
+    _impl = impl;
+  endfunction
+
+  /*
+    Method: info
+    Wrapper for info method call from printer
+
+    Parameters:
+      name - name of test used for $display
+      msg  - text to be displayed as info
+  */
+  static function void info(string name, string msg);
+    this_type printer;
+    printer = this_type::get();
+    printer._impl.info(name, msg);
+  endfunction
+
+  /*
+    Method: error
+    Wrapper for error method call from printer
+
+    Parameters:
+      name - name of test used for $display
+      msg  - text to be displayed as error
+  */
+  static function void error(string name, string msg);
+    this_type printer;
+    printer = this_type::get();
+    printer._impl.error(name, msg);
+  endfunction
+
+  /*
+    Method: lf
+    Wrapper for lf method call from printer
+  */
+  static function void lf();
+    this_type printer;
+    printer = this_type::get();
+    printer._impl.lf();
+  endfunction
+
+endclass
+


### PR DESCRIPTION
Hi, 
This small change puts consoles print of INFO and ERROR to single class witch can be easily overridden by user with his own implementation
E.g. just adding following code anywhere to compile list, we don't get time print in log:
```
class no_time_printer extends svunit_pkg::svunit_printer::default_printer;

  virtual function void info(string name, string msg);
    $display("INFO:  [%0s]: %s", name, msg);
  endfunction
  virtual function void error(string name, string msg);
    $display("ERROR: [%0s]: %s", name, msg);
  endfunction
  virtual function void lf();
    $display("");
  endfunction

  static bit v = register();

  static function bit register();
    no_time_printer mp = new();
    svunit_printer p = svunit_printer::get();
    p.set_implementation(mp);
    return 0;
  endfunction

endclass
```
Similarly logging to file can be added or something else.
This gives user some flexibility to log messages

Please review
Thanks
Maciej