### PR TITLE
Add possibility to specify directories where SVUnit looks for tests

### DIFF
--- a/bin/buildSVUnit
+++ b/bin/buildSVUnit
@@ -39,6 +39,7 @@ my @tests;
 my $mock;
 my $uvm;
 my $wavedrom;
+my @directory;
 my $help;
 
 
@@ -54,6 +55,7 @@ sub usage() {
   print "  -m|--mock                : includes the uvm_mock_pkg to the final build file\n";
   print "  -U|--uvm                 : build SVUnit with UVM\n";
   print "  -w|--wavedrom            : process json files as wavedrom output\n";
+  print "     --directory           : only build svunit on selected directories\n";
   print "  -h|--help                : prints this help screen\n";
   print "\n";
   exit 1;
@@ -176,6 +178,7 @@ GetOptions("o|out=s" => \$outdir,
            "m|mock" => \$mock,
            "U|uvm" => \$uvm,
            "w|wavedrom" => \$wavedrom,
+           "directory=s" => \@directory,
            "h|help" => \$help
            ) or usage();
 
@@ -204,6 +207,14 @@ if ($wavedrom) {
 }
 
 getFilelists;
-buildTestsuite($pwd);
+
+# Build a test suite for every directory passed in via --directory
+foreach (@directory) {
+    buildTestsuite($_);
+}
+# If --directory wasn't used, assume the test suite must be built using the current directory
+if (@directory < 1) {
+    buildTestsuite($pwd);
+}
 exit buildTestrunner;
 #print "Info: Found no unit tests. No SVUnit framework created.\n";

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -40,6 +40,7 @@ my @defines;
 my @filelists;
 my $uvm;
 my $wavedrom;
+my @directory;
 my @simargs;
 my @compileargs;
 my $outdir = ".";
@@ -64,6 +65,7 @@ sub usage () {
   print "  -m|--mixedsim <vhdlfile> : consolidated file list with VHDL files and command line switches\n";
   print "  -w|--wavedrom            : process json files as wavedrom output\n";
   print "     --filter <filter>     : specify which tests to run, as <test_module>.<test_name>\n";
+  print "     --directory           : only run svunit discovery on selected directories\n";
   print "  -h|--help                : prints this help screen\n";
   print "\n";
   exit 1;
@@ -97,6 +99,7 @@ GetOptions("l|log=s" => \$logfile,
            "t|test=s{,}" => \@tests,
            "filter=s" => \$filter,
            "w|wavedrom" => \$wavedrom,
+           "directory=s" => \@directory,
            "h|help" => \$help
            ) or usage();
 
@@ -181,6 +184,11 @@ if ($simulator eq "modelsim" or $simulator eq "riviera") {
 $cmd .= " +SVUNIT_FILTER=$filter";
 
 my $build_cmd = "buildSVUnit -o $outdir";
+
+foreach (@directory) {
+    $build_cmd .= " --directory $_";
+}
+
 foreach (@tests) {
   $build_cmd .= " -t $_";
 }


### PR DESCRIPTION
This fixes #166 by adding a new `--directory` flag on the `runSVUnit` and `buildSVUnit` scripts. This flag, which may be specified multiple times, specifies additional directories for `buildSVUnit` to use to build a test suite.

`runSVUnit` passes the value (or values) to `buildSVUnit`. `buildSVUnit` will try to build a test suite for each directory passed to it. If `--directory` is not specified, it defaults to building a test suite out of the current directory.