### PR TITLE
Fix #151: Check return code of vlog

### DIFF
--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -187,7 +187,7 @@ if ($simulator eq "modelsim" or $simulator eq "riviera") {
   if (!grep(/(^| )(-gui|-c|-i)( |$)/, @simargs)) {
     push @simargs, "-c";
   }
-  $cmd .= qq! @compileargs; vsim @simargs -lib work -do "run -all; quit" -l $logfile testrunner!;
+  $cmd .= qq! @compileargs && vsim @simargs -lib work -do "run -all; quit" -l $logfile testrunner!;
 } else {
   $cmd .= " @compileargs @simargs -top testrunner";
 }
@@ -216,5 +216,7 @@ if (system("$build_cmd")) {
   exit -1;
 }
 print $cmd . "\n";
-system("$cmd");
+if (system("$cmd")) {
+  exit -2;
+}
 system("svunit_user_feedback.pl")


### PR DESCRIPTION
`system("svunit_user_feedback.pl")` suppresses the return code of `vlog` when compilation fails. Our CI would report success with 0 test cases in those situations. 

I believe this should also fix #154.

I decided to return -2 to be able to differentiate with $build_cmd 
I can also add an error message as suggested in #43.