### PR TITLE
Fix warning related to string comparison

### DIFF
--- a/svunit_base/svunit_string_utils.svh
+++ b/svunit_base/svunit_string_utils.svh
@@ -13,7 +13,7 @@
     for (int i = 0; i < s.len(); i++) begin
       if (i == s.len()-1)
         parts.push_back(s.substr(last_char_position+1, i));
-      if (s[i] == char) begin
+      if (string'(s[i]) == char) begin
         parts.push_back(s.substr(last_char_position+1, i-1));
         last_char_position = i;
       end


### PR DESCRIPTION
`s[i]` returns a `byte`, whereas `char` is a `string`. DVT and VCS complain about this comparison, while Xcelium and QuestaSim are fine with it. No idea who is in the right here, but we don't want warnings in any of the tools.