### PR TITLE
Generate initial seed at simulation startup which then can be referenced to initialise the RNGs in a predictable manner on a per test basis.

### DIFF
--- a/svunit_base/svunit_testrunner.sv
+++ b/svunit_base/svunit_testrunner.sv
@@ -30,10 +30,19 @@ class svunit_testrunner extends svunit_base;
 
 
   /*
+    Variable to store seed randomly generated at simulation startup
+    This can then be referenced to initialise the RNGs
+    in a predictable manner on a per test basis
+  */
+  local int unsigned     svunit_initial_seed;
+
+
+  /*
     Interface
   */
   extern function new(string name);
   extern function void add_testsuite(svunit_testsuite suite);
+  extern function int unsigned get_initial_seed();
 
   extern function void report();
 
@@ -60,8 +69,18 @@ endclass
 */
 function svunit_testrunner::new(string name);
   super.new(name);
+  this.svunit_initial_seed = $urandom();
+  `INFO($sformatf("Initial svunit seed %0d", this.get_initial_seed()));
 endfunction
 
+/*
+  Method: get_initial_seed
+  Returns the initial seed generated at simulation startup
+*/
+
+function int unsigned svunit_testrunner::get_initial_seed();
+  return this.svunit_initial_seed;
+endfunction
 
 /*
   Method: add_testsuite


### PR DESCRIPTION
At the start of an SVTEST, the initial svunit seed is retrieved using testrunner.svunit_tr.get_initial_seed(), and this is used to set the seed of the process RNG using process::self().srandom.

e.g.

```
    `SVTEST(test_1)
        process::self().srandom(1 * testrunner.svunit_tr.get_initial_seed());
        <test_1>
    `SVTEST_END

    `SVTEST(test_2)
        process::self().srandom(2 * testrunner.svunit_tr.get_initial_seed());
        <test_2>
    `SVTEST_END

    `SVTEST(test_3)
        process::self().srandom(3 * testrunner.svunit_tr.get_initial_seed());
        <test_3>
    `SVTEST_END
```


Each test can have a different but predictable series of random numbers generated by adding a 'multiplier' to the initial seed.  This is important to have when a using the svunit 'filter' option in order to to reproduce a specific test failure.  Otherwise all tests would need to be run to generate the same sequence of random numbers.