### PR TITLE
Workaround for Vivado forward typedef error

### DIFF
--- a/svunit_base/svunit_filter.svh
+++ b/svunit_base/svunit_filter.svh
@@ -22,7 +22,9 @@
  */
 class filter;
 
+`ifndef XILINX_SIMULATOR
   /* local */ typedef class filter_for_single_pattern;
+`endif
 
   /* local */ typedef filter_for_single_pattern array_of_filters[];
   /* local */ typedef string array_of_string[];


### PR DESCRIPTION
Hi Tudor,

When using SVUnit with Xilinx Vivado I got the following error:

```
INFO: [VRFC 10-2263] Analyzing SystemVerilog file "/opt/svunit/svunit_base/svunit_pkg.sv" into library work
ERROR: [VRFC 10-3358] forward typedef 'filter_for_single_pattern' is already fully defined [/opt/svunit/svunit_base/svunit_filter.svh:25]
ERROR: [VRFC 10-8530] package 'svunit_pkg' is ignored due to previous errors [/opt/svunit/svunit_base/svunit_pkg.sv:22]
```

This PR fixes this issue. I'm unsure, whether this is due to an usage error but I tried several things and nothing other worked.

At least I can confirm, that the HEAD of SVUnit is working with Xilinx Vivado (and this PR).

I may be able to provide some documentation on how to use SVUnit with Vivado. Are you interested?