### PR TITLE
Fix unmatched typedef in class which only causes compile errors in some tools

### DIFF
--- a/svunit_base/svunit_filter.svh
+++ b/svunit_base/svunit_filter.svh
@@ -22,8 +22,6 @@
  */
 class filter;
 
-  /* local */ typedef class filter_for_single_pattern;
-
   /* local */ typedef filter_for_single_pattern array_of_filters[];
   /* local */ typedef string array_of_string[];
 


### PR DESCRIPTION
The `typedef` is a remnant from when `filter_for_single_pattern` was a nested class. This was moved outside, because Verilator doesn't support nested classes. Interestingly, only Xilinx Vivado flags an error (a wrong error, but an error nevertheless), while all other tools happily compile.