### PR TITLE
Fix Warning/behaviour in `SVUNIT_CLK_GEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix warning in VCS when using `SVUNIT_CLK_GEN
 
 ## [3.37.0] - 2023-09-18
 

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -217,7 +217,7 @@ end \
             if( svunit_ut.is_running() ) \
                 #_half_period _clk_variable = !_clk_variable; \
             else \
-                wait( svunit_ut.is_running() ); \
+                svunit_ut.wait_for_running(); \
         end \
     end
 

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -217,7 +217,7 @@ end \
             if( svunit_ut.is_running() ) \
                 #_half_period _clk_variable = !_clk_variable; \
             else \
-                svunit_ut.wait_for_running(); \
+                svunit_ut.__wait_until_started(); \
         end \
     end
 

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -60,6 +60,7 @@ class svunit_testcase extends svunit_base;
   extern function void start();
   extern function void stop();
   extern function bit  is_running();
+  extern task wait_for_running();
 
   extern function void update_exit_status();
   extern function void report();
@@ -188,6 +189,13 @@ function bit svunit_testcase::is_running();
   return running;
 endfunction
 
+/*
+  Method: wait_for_running
+  Returns when this test is running
+*/
+task svunit_testcase::wait_for_running();
+  wait(running);
+endtask
 
 /*
   Methos: update_exit_status

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -60,7 +60,7 @@ class svunit_testcase extends svunit_base;
   extern function void start();
   extern function void stop();
   extern function bit  is_running();
-  extern task wait_for_running();
+  extern task __wait_until_started();
 
   extern function void update_exit_status();
   extern function void report();
@@ -190,10 +190,10 @@ function bit svunit_testcase::is_running();
 endfunction
 
 /*
-  Method: wait_for_running
+  Method: __wait_until_started
   Returns when this test is running
 */
-task svunit_testcase::wait_for_running();
+task svunit_testcase::__wait_until_started();
   wait(running);
 endtask
 


### PR DESCRIPTION
VCS gives the following warning when using the `SVUNIT_CLK_GEN macro:

Warning-[FCWAIEW] FuncCall Without Arguments In Wait/Event
my_unit_test.sv, 70
"svunit_ut.is_running()"
  Function calls inside wait/event expression are sensitive only to arguments.
  svunit_ut.is_running() is called without any arguments which may not unblock
  wait/event expression

Furthermore I observed the `SVUNIT_CLK_GEN macro is not starting the clock for the second, thired, etc. unit tests running in the same testsuite. 

This pull request fixes both warning and behaviour. 
