### PR TITLE
Fix tests that trigger internal execution error

### DIFF
--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -164,7 +164,7 @@ module dummy_unit_test;
 endmodule
     ''')
 
-    subprocess.check_call(['runSVUnit', '-s', simulator, '--filter', 'some_string'], cwd=tmp_path)
+    subprocess.call(['runSVUnit', '-s', simulator, '--filter', 'some_string'], cwd=tmp_path)
 
     log = tmp_path.joinpath('run.log')
     assert 'fatal' in log.read_text().lower()
@@ -200,7 +200,7 @@ module dummy_unit_test;
 endmodule
     ''')
 
-    subprocess.check_call(['runSVUnit', '-s', simulator, '--filter', 'a.b.c'], cwd=tmp_path)
+    subprocess.call(['runSVUnit', '-s', simulator, '--filter', 'a.b.c'], cwd=tmp_path)
 
     log = tmp_path.joinpath('run.log')
     assert 'fatal' in log.read_text().lower()
@@ -236,15 +236,15 @@ module dummy_unit_test;
 endmodule
     ''')
 
-    subprocess.check_call(['runSVUnit', '-s', simulator, '--filter', 'foo*.bar'], cwd=tmp_path)
+    subprocess.call(['runSVUnit', '-s', simulator, '--filter', 'foo*.bar'], cwd=tmp_path)
     log = tmp_path.joinpath('run.log')
     assert 'fatal' in log.read_text().lower()
 
-    subprocess.check_call(['runSVUnit', '-s', simulator, '--filter', 'foo.bar*'], cwd=tmp_path)
+    subprocess.call(['runSVUnit', '-s', simulator, '--filter', 'foo.bar*'], cwd=tmp_path)
     log = tmp_path.joinpath('run.log')
     assert 'fatal' in log.read_text().lower()
 
-    subprocess.check_call(['runSVUnit', '-s', simulator, '--filter', '*foo.bar'], cwd=tmp_path)
+    subprocess.call(['runSVUnit', '-s', simulator, '--filter', '*foo.bar'], cwd=tmp_path)
     log = tmp_path.joinpath('run.log')
     assert 'fatal' in log.read_text().lower()
 


### PR DESCRIPTION
Wrong values for `--filter` are handled in SystemVerilog and will trigger an internal execution error instead of a command line usage error.