### PR TITLE
Fix Vivado compile warning at `$fatal()` method call

### DIFF
--- a/svunit_base/svunit_internal_defines.svh
+++ b/svunit_base/svunit_internal_defines.svh
@@ -23,5 +23,5 @@
   `ifndef XILINX_SIMULATOR \
     $fatal(0, s); \
   `else \
-    $fatal(s); \
+    $fatal(1, s); \
   `endif


### PR DESCRIPTION
Vivado has multiple [issues] with `$fatal()`. A finish number of `1` causes a fatal error to be reported. Omitting the finish number caused Vivado to assume a finish number of `1`, which is why it worked.

[issues]: https://support.xilinx.com/s/question/0D54U00007bvYbZSAU/bug-report-various-issues-with-fatal-system-task-behaves-like-regular-finish-when-called-with-finish-number-0-no-nonzero-exit-code-typo-in-compile-warning?language=en_US