### PR TITLE
Added cmdline argument for xelab options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add support for Xilinx Vivado (TM) Simulator
+- Add possibility to specify elaboration options
 
 ### Fixed
 - Fix warning in VCS when using `SVUNIT_CLK_GEN

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -222,7 +222,7 @@ if ($simulator eq "modelsim" or $simulator eq "riviera") {
 } elsif ($simulator eq "xsim") {
   $cmd .= qq! @compileargs && xelab testrunner @elabargs && xsim @simargs --R --log $logfile testrunner!;
 } else {
-  $cmd .= " @compileargs @simargs -top testrunner";
+  $cmd .= " @compileargs @elabargs @simargs -top testrunner";
 }
 
 if (defined $filter && $simulator ne "verilator") {

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -48,6 +48,7 @@ my $wavedrom;
 my @directory;
 my @simargs;
 my @compileargs;
+my @elabargs;
 my $outdir = ".";
 my $clean;
 my $vhdlfile;
@@ -58,13 +59,14 @@ my $help;
 
 sub usage () {
   print "Usage:  runSVUnit [-s|--sim <simulator> -l|--log <log> -d|--define <macro> -f|--filelist <file> -U|-uvm -m|-mixedsim <vhdlfile>\n";
-  print "                  -r|--r_arg <option> -c|--c_arg <option> -o|--out <dir> -t|--test <test> --filter <filter>]\n";
+  print "                  -r|--r_arg <option> -c|--c_arg <option> -e|--e_arg <option> -o|--out <dir> -t|--test <test> --filter <filter>]\n";
   print "  -s|--sim <simulator>     : simulator is either of questa, modelsim, riviera, ius, xcelium, vcs, dsim, verilator\n";
   print "  -l|--log <log>           : simulation log file (default: run.log)\n";
   print "  -d|--define <macro>      : appended to the command line as +define+<macro>\n";
   print "  -f|--filelist <file>     : some verilog file list\n";
   print "  -r|--r_arg <option>      : specify additional runtime options\n";
   print "  -c|--c_arg <option>      : specify additional compile options\n";
+  print "  -e|--e_arg <option>      : specify additional elaboration options\n";
   print "  -U|--uvm                 : run SVUnit with UVM\n";
   print "  -o|--out                 : output directory for tmp and simulation files\n";
   print "  -t|--test                : specifies a unit test to run (multiple can be given)\n";
@@ -101,6 +103,7 @@ GetOptions("l|log=s" => \$logfile,
            "U|uvm" => \$uvm,
            "r|r_arg=s" => \@simargs,
            "c|c_arg=s" => \@compileargs,
+           "e|e_arg=s" => \@elabargs,
            "o|out=s" => \$outdir,
            "m|mixedsim=s" => \$vhdlfile,
            "t|test=s{,}" => \@tests,
@@ -217,7 +220,7 @@ if ($simulator eq "modelsim" or $simulator eq "riviera") {
   }
   $cmd .= qq! && obj_dir/Vtestrunner $verilator_simargs 2>&1 | tee $logfile !;
 } elsif ($simulator eq "xsim") {
-  $cmd .= qq! @compileargs && xelab testrunner && xsim @simargs --R --log $logfile testrunner!;
+  $cmd .= qq! @compileargs && xelab testrunner @elabargs && xsim @simargs --R --log $logfile testrunner!;
 } else {
   $cmd .= " @compileargs @simargs -top testrunner";
 }

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -172,7 +172,7 @@ if ($simulator eq "modelsim" or $simulator eq "riviera") {
   $cmd .= "-f $vhdlfile " if $vhdlfile;
 } elsif ($simulator eq "verilator") {
   $cmd .= "verilator --binary --top-module testrunner";
-  $cmd .= qq! @compileargs!;
+  $cmd .= qq! @compileargs @elabargs!;
 } elsif ($simulator eq "xsim") {
   $cmd .= "xvhdl -f $vhdlfile && " if $vhdlfile;
   $cmd .= "xvlog --sv --log $vlogfile ";

--- a/bin/runSVUnit
+++ b/bin/runSVUnit
@@ -211,7 +211,8 @@ if ($simulator eq "modelsim" or $simulator eq "riviera") {
   if (!grep(/(^| )(-gui|-c|-i)( |$)/, @simargs)) {
     push @simargs, "-c";
   }
-  $cmd .= qq! @compileargs && vsim @simargs -lib work -do "run -all; quit" -l $logfile testrunner!;
+  my $vopt_elabargs = @elabargs ? qq!-voptargs="@elabargs"! : "";
+  $cmd .= qq! @compileargs && vsim $vopt_elabargs @simargs -lib work -do "run -all; quit" -l $logfile testrunner!;
 } elsif ($simulator eq "verilator") {
   my $verilator_simargs = "";
   $verilator_simargs .= " @simargs";

--- a/docs/source/running_unit_tests.rst
+++ b/docs/source/running_unit_tests.rst
@@ -49,7 +49,7 @@ Through the use of \`include directives, both the unit test template and corresp
 Adding Run Time and/or Compile Time Options
 -------------------------------------------
 
-It is possible to specified compile and run time options using the '-c_arg' and '-r_arg' switches respectively. All compile and run time arguments are passed directly to the simulator command line.
+It is possible to specify compile and run time options using the '-c_arg' and '-r_arg' switches respectively. All compile and run time arguments are passed directly to the simulator command line.
 
 
 Enable UVM Component Unit Testing

--- a/docs/source/running_unit_tests.rst
+++ b/docs/source/running_unit_tests.rst
@@ -11,6 +11,7 @@ SVUnit unit tests are run using runSVUnit. Usage of runSVUnit is as follows::
     -f|--filelist <file>     : some verilog file list
     -r|--r_arg <option>      : specify additional runtime options
     -c|--c_arg <option>      : specify additional compile options
+    -e|--e_arg <option>      : specify additional elaboration options
     -U|--uvm                 : run SVUnit with UVM
     -o|--out                 : output directory for tmp and simulation files
     -t|--test                : specifies a unit test to run (multiple can be given)
@@ -46,10 +47,10 @@ Through the use of \`include directives, both the unit test template and corresp
     The file svunit.f is automatically included for compilation provided it exists. Thus, files can be added to svunit.f without having to specify '-f svunit.f' on the command line.
 
 
-Adding Run Time and/or Compile Time Options
--------------------------------------------
+Adding Run Time and/or Compile and/or Elaboration Options
+---------------------------------------------------------
 
-It is possible to specify compile and run time options using the '-c_arg' and '-r_arg' switches respectively. All compile and run time arguments are passed directly to the simulator command line.
+It is possible to specify compile and run time options using the '-c_arg', '-e_arg' and '-r_arg' switches respectively. All compile, elaboration and run time arguments are passed directly to the simulator command line.
 
 
 Enable UVM Component Unit Testing

--- a/test/test_frmwrk.py
+++ b/test/test_frmwrk.py
@@ -640,3 +640,18 @@ def test_called_with_filter_option__plusarg_passed(tmpdir, monkeypatch):
         subprocess.check_call(['runSVUnit', '--filter', 'foo.bar'])
 
         assert '+SVUNIT_FILTER=foo.bar' in pathlib.Path('fake_tool.log').read_text()
+
+
+def test_vivado_can_take_elab_args(tmpdir, monkeypatch):
+    with tmpdir.as_cwd():
+        fake_tool('xsim', log_name_is_tool_name=True)
+        fake_tool('xvlog', log_name_is_tool_name=True)
+        fake_tool('xelab',log_name_is_tool_name=True)
+
+        monkeypatch.setenv('PATH', get_path_without_sims())
+        monkeypatch.setenv('PATH', '.', prepend=os.pathsep)
+
+        pathlib.Path('dummy_unit_test.sv').write_text('dummy')
+        subprocess.check_call(['runSVUnit', '-e_arg', 'some-arg'])
+
+        assert 'some-arg' in pathlib.Path('fake_xelab.log').read_text()

--- a/test/test_frmwrk.py
+++ b/test/test_frmwrk.py
@@ -655,3 +655,16 @@ def test_vivado_can_take_elab_args(tmpdir, monkeypatch):
         subprocess.check_call(['runSVUnit', '-e_arg', 'some-arg'])
 
         assert 'some-arg' in pathlib.Path('fake_xelab.log').read_text()
+
+
+def test_xcelium_can_take_elab_args(tmpdir, monkeypatch):
+    with tmpdir.as_cwd():
+        fake_tool('xrun', log_name_is_tool_name=True)
+
+        monkeypatch.setenv('PATH', get_path_without_sims())
+        monkeypatch.setenv('PATH', '.', prepend=os.pathsep)
+
+        pathlib.Path('dummy_unit_test.sv').write_text('dummy')
+        subprocess.check_call(['runSVUnit', '-e_arg', 'some-arg'])
+
+        assert 'some-arg' in pathlib.Path('fake_xrun.log').read_text()

--- a/test/test_frmwrk.py
+++ b/test/test_frmwrk.py
@@ -698,3 +698,16 @@ def test_questasim_can_handle_no_elab_args(tmpdir, monkeypatch):
         subprocess.check_call(['runSVUnit'])
 
         assert '-voptargs' not in pathlib.Path('fake_vsim.log').read_text()
+
+
+def test_verilator_can_take_elab_args(tmpdir, monkeypatch):
+    with tmpdir.as_cwd():
+        fake_tool('verilator', log_name_is_tool_name=True)
+
+        monkeypatch.setenv('PATH', get_path_without_sims())
+        monkeypatch.setenv('PATH', '.', prepend=os.pathsep)
+
+        pathlib.Path('dummy_unit_test.sv').write_text('dummy')
+        subprocess.check_call(['runSVUnit', '-e_arg', 'some-arg'])
+
+        assert 'some-arg' in pathlib.Path('fake_verilator.log').read_text()

--- a/test/test_frmwrk.py
+++ b/test/test_frmwrk.py
@@ -668,3 +668,33 @@ def test_xcelium_can_take_elab_args(tmpdir, monkeypatch):
         subprocess.check_call(['runSVUnit', '-e_arg', 'some-arg'])
 
         assert 'some-arg' in pathlib.Path('fake_xrun.log').read_text()
+
+
+def test_questasim_can_take_elab_args(tmpdir, monkeypatch):
+    with tmpdir.as_cwd():
+        fake_tool('vsim', log_name_is_tool_name=True)
+        fake_tool('vlib', log_name_is_tool_name=True)
+        fake_tool('vlog', log_name_is_tool_name=True)
+
+        monkeypatch.setenv('PATH', get_path_without_sims())
+        monkeypatch.setenv('PATH', '.', prepend=os.pathsep)
+
+        pathlib.Path('dummy_unit_test.sv').write_text('dummy')
+        subprocess.check_call(['runSVUnit', '-e_arg', 'some-arg'])
+
+        assert '-voptargs=some-arg' in pathlib.Path('fake_vsim.log').read_text()
+
+
+def test_questasim_can_handle_no_elab_args(tmpdir, monkeypatch):
+    with tmpdir.as_cwd():
+        fake_tool('vsim', log_name_is_tool_name=True)
+        fake_tool('vlib', log_name_is_tool_name=True)
+        fake_tool('vlog', log_name_is_tool_name=True)
+
+        monkeypatch.setenv('PATH', get_path_without_sims())
+        monkeypatch.setenv('PATH', '.', prepend=os.pathsep)
+
+        pathlib.Path('dummy_unit_test.sv').write_text('dummy')
+        subprocess.check_call(['runSVUnit'])
+
+        assert '-voptargs' not in pathlib.Path('fake_vsim.log').read_text()

--- a/test/test_frmwrk.py
+++ b/test/test_frmwrk.py
@@ -17,9 +17,9 @@ def get_path_without_sims():
     return os.path.pathsep.join(paths)
 
 
-def fake_tool(name):
+def fake_tool(name, log_name_is_tool_name=False):
     executable = pathlib.Path(name)
-    log_file = 'fake_tool.log'
+    log_file = 'fake_tool.log' if not log_name_is_tool_name else f'fake_{name}.log'
     script = [
             'echo "{} called" > {}'.format(name, log_file),
             'echo "args:" >> {}'.format(log_file),


### PR DESCRIPTION
Hi Tudor,

Xilinx Vivado uses a different set of commandline arguments to `xvlog` and `xelab` (cf. [Xilinx documentation](https://docs.xilinx.com/r/en-US/ug900-vivado-logic-simulation/Parsing-Design-Files-xvhdl-and-xvlog) and following chapters).

This PR adds the ability to set options for the `xelab` command through an additional commandline parameter.