### PR TITLE
Fix wrong parameter in `settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.pythondefaultInterpreterPath": "${workspaceFolder}/test/.venv/bin/python3",
+    "python.defaultInterpreterPath": "${workspaceFolder}/test/.venv/bin/python3",
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.cwd": "${workspaceFolder}/test"


### PR DESCRIPTION
Parameter `python.pythondefaultInterpreterPath` in the `.vscode/settings.json` file contains a typo.

The correct name is [python.defaultInterpreterPath](https://code.visualstudio.com/docs/python/settings-reference#_general-python-settings:~:text=defaultInterpreterPath)