### PR TITLE
Use Verilator version 5.024 for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  VERILATOR_VERSION: v5.012
+  VERILATOR_VERSION: v5.024
 
 jobs:
   build:


### PR DESCRIPTION
Notably, this version provides better support for `fork...join`.