### PR TITLE
Separate declaration from execution of SVTESTs

### DIFF
--- a/bin/create_testsuite.pl
+++ b/bin/create_testsuite.pl
@@ -226,6 +226,7 @@ sub CreateTestSuite() {
   print OUTFILE "  function void build();\n";
   foreach $item ( @instance_names ) {
     print OUTFILE "    $item.build();\n";
+    print OUTFILE "    $item.__register_tests();\n";
     $cnt++;
   }
 

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -178,7 +178,7 @@
     \
     virtual task run(); \
       fork \
-        run_``_NAME_``(); \
+        SVTEST_``_NAME_``(); \
         `SVUNIT_FUSE \
       join_any \
     endtask \
@@ -195,7 +195,7 @@
   \
   /* Need to define test body in a separate task due to Verilator issue when module variables are used in class methods. */ \
   /* See https://github.com/verilator/verilator/issues/5060 */ \
-  task automatic run_``_NAME_``();
+  task automatic SVTEST_``_NAME_``();
 
 
 /*

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -176,18 +176,9 @@
       super.new(`__svunit_stringify(_NAME_)); \
     endfunction \
     \
-    local task __run();
-
-/*
-  Macro: `SVTEST_END
-  END an svunit test within an SVUNIT_TEST_BEGIN/END block
-*/
-`define SVTEST_END \
-    endtask \
-    \
     virtual task run(); \
       fork \
-        __run(); \
+        run_``_NAME_``(); \
         `SVUNIT_FUSE \
       join_any \
     endtask \
@@ -200,7 +191,19 @@
       teardown(); \
     endtask \
     \
-  endclass
+  endclass \
+  \
+  /* Need to define test body in a separate task due to Verilator issue when module variables are used in class methods. */ \
+  /* See https://github.com/verilator/verilator/issues/5060 */ \
+  task automatic run_``_NAME_``();
+
+
+/*
+  Macro: `SVTEST_END
+  END an svunit test within an SVUNIT_TEST_BEGIN/END block
+*/
+`define SVTEST_END \
+  endtask
 
 `define SVUNIT_FUSE \
 `ifdef SVUNIT_TIMEOUT \

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -150,22 +150,7 @@
         svunit_ut.add_junit_test_case(_testName); \
         svunit_ut.start(); \
         setup(); \
-        fork \
-          begin \
-            fork \
-              test.run(); \
-              begin \
-                if (svunit_ut.get_error_count() == local_error_count) begin \
-                  svunit_ut.wait_for_error(); \
-                end \
-              end \
-            join_any \
-`ifndef VERILATOR \
-            #0; \
-            disable fork; \
-`endif \
-          end \
-        join \
+        svunit_ut.__run_test(test); \
         svunit_ut.stop(); \
         teardown(); \
         if (svunit_ut.get_error_count() == local_error_count) \

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -134,22 +134,13 @@
   START a block of unit tests
 */
 `define SVUNIT_TESTS_BEGIN \
-  task automatic run(); \
-    svunit_pkg::svunit_test tests[]; \
-    \
-    if ($test$plusargs("SVUNIT_LIST_TESTS")) \
-      $display(name); \
-    else \
-      `INFO("RUNNING"); \
-    \
-    tests = svunit_ut.get_tests(); \
-    foreach (tests[i]) begin \
+  task automatic __run_test(svunit_pkg::svunit_test test); \
       if ($test$plusargs("SVUNIT_LIST_TESTS")) begin \
-        string test_name = tests[i].get_name(); \
+        string test_name = test.get_name(); \
         $display({ "    ", test_name }); /* XXX WORKAROUND Verilator doesn't like it when we stringify the macro argument in the concatenation */ \
       end \
-      else if (svunit_pkg::_filter.is_selected(svunit_ut, tests[i].get_name())) begin \
-        string _testName = tests[i].get_name(); \
+      else if (svunit_pkg::_filter.is_selected(svunit_ut, test.get_name())) begin \
+        string _testName = test.get_name(); \
         integer local_error_count = svunit_ut.get_error_count(); \
         string fileName; \
         int lineNumber; \
@@ -162,7 +153,7 @@
         fork \
           begin \
             fork \
-              tests[i].run(); \
+              test.run(); \
               begin \
                 if (svunit_ut.get_error_count() == local_error_count) begin \
                   svunit_ut.wait_for_error(); \
@@ -183,6 +174,20 @@
           `INFO($sformatf(`"%s::FAILED`", _testName)); \
         svunit_ut.update_exit_status(); \
       end \
+  endtask \
+  \
+  \
+  task automatic run(); \
+    svunit_pkg::svunit_test tests[]; \
+    \
+    if ($test$plusargs("SVUNIT_LIST_TESTS")) \
+      $display(name); \
+    else \
+      `INFO("RUNNING"); \
+    \
+    tests = svunit_ut.get_tests(); \
+    foreach (tests[i]) begin \
+      __run_test(tests[i]); \
     end \
   endtask \
   \

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -216,10 +216,12 @@
 `define SVTEST(_NAME_) \
   typedef class _NAME_; \
   \
-  initial begin \
-    static _NAME_ test = new(); \
+  bit __is_``_NAME_``_registered = __register_``_NAME_``(); \
+  function automatic bit __register_``_NAME_``(); \
+    _NAME_ test = new(); \
     __tests.push_back(test); \
-  end \
+    return 1; \
+  endfunction \
   \
   class _NAME_ extends svunit_pkg::svunit_test; \
     \

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -168,7 +168,6 @@
                   svunit_ut.wait_for_error(); \
                 end \
               end \
-              `SVUNIT_FUSE \
             join_any \
 `ifndef VERILATOR \
             #0; \
@@ -223,13 +222,20 @@
       super.new(`__svunit_stringify(_NAME_)); \
     endfunction \
     \
-    virtual task run();
+    local task __run();
 
 /*
   Macro: `SVTEST_END
   END an svunit test within an SVUNIT_TEST_BEGIN/END block
 */
 `define SVTEST_END \
+    endtask \
+    \
+    virtual task run(); \
+      fork \
+        __run(); \
+        `SVUNIT_FUSE \
+      join_any \
     endtask \
   endclass
 

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -134,46 +134,8 @@
   START a block of unit tests
 */
 `define SVUNIT_TESTS_BEGIN \
-  task automatic __run_test(svunit_pkg::svunit_test test); \
-      if ($test$plusargs("SVUNIT_LIST_TESTS")) begin \
-        string test_name = test.get_name(); \
-        $display({ "    ", test_name }); /* XXX WORKAROUND Verilator doesn't like it when we stringify the macro argument in the concatenation */ \
-      end \
-      else if (svunit_pkg::_filter.is_selected(svunit_ut, test.get_name())) begin \
-        string _testName = test.get_name(); \
-        integer local_error_count = svunit_ut.get_error_count(); \
-        string fileName; \
-        int lineNumber; \
-        \
-        `INFO($sformatf(`"%s::RUNNING`", _testName)); \
-        svunit_pkg::current_tc = svunit_ut; \
-        svunit_ut.add_junit_test_case(_testName); \
-        svunit_ut.start(); \
-        test.unit_test_setup(); \
-        svunit_ut.__run_test(test); \
-        svunit_ut.stop(); \
-        test.unit_test_teardown(); \
-        if (svunit_ut.get_error_count() == local_error_count) \
-          `INFO($sformatf(`"%s::PASSED`", _testName)); \
-        else \
-          `INFO($sformatf(`"%s::FAILED`", _testName)); \
-        svunit_ut.update_exit_status(); \
-      end \
-  endtask \
-  \
-  \
   task automatic run(); \
-    svunit_pkg::svunit_test tests[]; \
-    \
-    if ($test$plusargs("SVUNIT_LIST_TESTS")) \
-      $display(name); \
-    else \
-      `INFO("RUNNING"); \
-    \
-    tests = svunit_ut.get_tests(); \
-    foreach (tests[i]) begin \
-      __run_test(tests[i]); \
-    end \
+    svunit_ut.run(); \
   endtask \
   \
   svunit_pkg::svunit_test __tests[$]; \

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -149,10 +149,10 @@
         svunit_pkg::current_tc = svunit_ut; \
         svunit_ut.add_junit_test_case(_testName); \
         svunit_ut.start(); \
-        setup(); \
+        test.unit_test_setup(); \
         svunit_ut.__run_test(test); \
         svunit_ut.stop(); \
-        teardown(); \
+        test.unit_test_teardown(); \
         if (svunit_ut.get_error_count() == local_error_count) \
           `INFO($sformatf(`"%s::PASSED`", _testName)); \
         else \
@@ -229,6 +229,15 @@
         `SVUNIT_FUSE \
       join_any \
     endtask \
+    \
+    virtual task unit_test_setup(); \
+      setup(); \
+    endtask \
+    \
+    virtual task unit_test_teardown(); \
+      teardown(); \
+    endtask \
+    \
   endclass
 
 `define SVUNIT_FUSE \

--- a/svunit_base/svunit_globals.svh
+++ b/svunit_base/svunit_globals.svh
@@ -16,6 +16,10 @@
 //
 //###########################################################################
 
+typedef class svunit_testcase;
+typedef class filter;
+
+
 // The current testcase that is being executed.
 svunit_testcase current_tc;
 

--- a/svunit_base/svunit_pkg.sv
+++ b/svunit_base/svunit_pkg.sv
@@ -23,6 +23,7 @@
 package svunit_pkg;
 
   const string svunit_version = { "SVUnit ", `__svunit_stringify(`SVUNIT_VERSION) };
+  `include "svunit_globals.svh"
 
   `include "svunit_types.svh"
   `include "svunit_string_utils.svh"
@@ -33,5 +34,5 @@ package svunit_pkg;
   `include "svunit_testrunner.sv"
   `include "svunit_filter_for_single_pattern.svh"
   `include "svunit_filter.svh"
-  `include "svunit_globals.svh"
+
 endpackage

--- a/svunit_base/svunit_test.svh
+++ b/svunit_base/svunit_test.svh
@@ -26,6 +26,8 @@ virtual class svunit_test extends svunit_base;
   endfunction
 
 
+  pure virtual task unit_test_setup();
   pure virtual task run();
+  pure virtual task unit_test_teardown();
 
 endclass

--- a/svunit_base/svunit_test.svh
+++ b/svunit_base/svunit_test.svh
@@ -1,6 +1,6 @@
 //###########################################################################
 //
-//  Copyright 2011-2024 The SVUnit Authors.
+//  Copyright 2024 The SVUnit Authors.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -16,22 +16,16 @@
 //
 //###########################################################################
 
-`include "svunit_defines.svh"
-`include "svunit_version_defines.svh"
-`include "svunit_internal_defines.svh"
+/*
+  Base class for tests defined using the `SVTEST macro
+*/
+virtual class svunit_test extends svunit_base;
 
-package svunit_pkg;
+  function new(string name);
+    super.new(name);
+  endfunction
 
-  const string svunit_version = { "SVUnit ", `__svunit_stringify(`SVUNIT_VERSION) };
 
-  `include "svunit_types.svh"
-  `include "svunit_string_utils.svh"
-  `include "svunit_base.sv"
-  `include "svunit_test.svh"
-  `include "svunit_testcase.sv"
-  `include "svunit_testsuite.sv"
-  `include "svunit_testrunner.sv"
-  `include "svunit_filter_for_single_pattern.svh"
-  `include "svunit_filter.svh"
-  `include "svunit_globals.svh"
-endpackage
+  pure virtual task run();
+
+endclass

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -94,6 +94,28 @@ class svunit_testcase extends svunit_base;
     return junit_test_cases;
   endfunction
 
+
+  task __run_test(svunit_test test);
+    integer local_error_count = get_error_count();
+
+    fork
+      begin
+        fork
+          test.run();
+          begin
+            if (get_error_count() == local_error_count) begin
+              wait_for_error();
+            end
+          end
+        join_any
+`ifndef VERILATOR
+        #0;
+        disable fork;
+`endif
+      end
+    join
+  endtask
+
 endclass
 
 

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -1,6 +1,6 @@
 //###########################################################################
 //
-//  Copyright 2011 The SVUnit Authors.
+//  Copyright 2011-2024 The SVUnit Authors.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class svunit_testcase extends svunit_base;
   */
   local bit running = 0;
 
+  local svunit_test tests[$];
   local junit_xml::TestCase current_junit_test_case;
   local junit_xml::TestCase junit_test_cases[$];
 
@@ -67,6 +68,18 @@ class svunit_testcase extends svunit_base;
 
   extern virtual task setup();
   extern virtual task teardown();
+
+
+  function void add_test(svunit_test test);
+    tests.push_back(test);
+  endfunction
+
+
+  /* local */ typedef svunit_test array_of_tests[];
+
+  function array_of_tests get_tests();
+    return tests;
+  endfunction
 
 
   function void add_junit_test_case(string name);

--- a/test/frmwrk_3/testsuite.gold
+++ b/test/frmwrk_3/testsuite.gold
@@ -3,8 +3,8 @@ module PWD_testsuite;
 
   string name = "PWD_ts";
   svunit_testsuite svunit_ts;
-  
-  
+
+
   //===================================
   // These are the unit tests that we
   // want included in this testsuite
@@ -18,7 +18,9 @@ module PWD_testsuite;
   //===================================
   function void build();
     test0_ut.build();
+    test0_ut.__register_tests();
     test1_ut.build();
+    test1_ut.__register_tests();
     svunit_ts = new(name);
     svunit_ts.add_testcase(test0_ut.svunit_ut);
     svunit_ts.add_testcase(test1_ut.svunit_ut);

--- a/test/sim_4/dut_unit_test.sv
+++ b/test/sim_4/dut_unit_test.sv
@@ -9,7 +9,7 @@ module dut_unit_test;
 
 
   //===================================
-  // This is the UUT that we're 
+  // This is the UUT that we're
   // running the Unit Tests on
   //===================================
   dut my_dut();
@@ -34,7 +34,7 @@ module dut_unit_test;
 
 
   //===================================
-  // Here we deconstruct anything we 
+  // Here we deconstruct anything we
   // need after running the Unit Tests
   //===================================
   task teardown();
@@ -59,7 +59,9 @@ module dut_unit_test;
   //===================================
   `SVUNIT_TESTS_BEGIN
 
+  `SVTEST(dummy)
     #(1);
+  `SVTEST_END
 
   `SVUNIT_TESTS_END
 

--- a/test/templates/testsuite_with_1_unittest.gold
+++ b/test/templates/testsuite_with_1_unittest.gold
@@ -17,6 +17,7 @@ module PWD_testsuite;
   //===================================
   function void build();
     MYNAME_ut.build();
+    MYNAME_ut.__register_tests();
     svunit_ts = new(name);
     svunit_ts.add_testcase(MYNAME_ut.svunit_ut);
   endfunction

--- a/test/templates/testsuite_with_2_unittest.gold
+++ b/test/templates/testsuite_with_2_unittest.gold
@@ -18,7 +18,9 @@ module PWD_testsuite;
   //===================================
   function void build();
     MYNAME1_ut.build();
+    MYNAME1_ut.__register_tests();
     MYNAME2_ut.build();
+    MYNAME2_ut.__register_tests();
     svunit_ts = new(name);
     svunit_ts.add_testcase(MYNAME1_ut.svunit_ut);
     svunit_ts.add_testcase(MYNAME2_ut.svunit_ut);

--- a/test/test_sim.py
+++ b/test/test_sim.py
@@ -197,7 +197,7 @@ def test_sim_13(datafiles, simulator):
     with datafiles.as_cwd():
         subprocess.check_call(['runSVUnit', '-s', simulator])
 
-        expect_string(br"ERROR: \[50\]\[dut_ut\]: fail_if: svunit_timeout \(at .*/dut_unit_test.sv line:62\)", 'run.log')
+        expect_string(br"ERROR: \[50\]\[dut_ut\]: fail_if: svunit_timeout \(at .*/dut_unit_test.sv line:60\)", 'run.log')
         expect_string(br"INFO:  \[99\]\[dut_ut\]: no_timeout::PASSED", 'run.log')
 
 


### PR DESCRIPTION
This will enable multiple things:
- easily implement #207 (at least the part related to test modules without any tests)
- centralize handling of JUnit XML dumps
- declare classes before `SVTESTs` (useful, for example, to declare a fake right next to the test it will be used in)

Tested with:

- [ ] DSim
- [x] QuestaSim
- [ ] VCS
- [x] Verilator
- [x] Vivado
- [x] Xcelium