### PR TITLE
Stop printing messages for test cases where no tests are selected

### DIFF
--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -113,11 +113,7 @@ class svunit_testcase extends svunit_base;
 
 
   local task run_tests();
-    svunit_test selected_tests[$];
-    foreach (tests[i])
-      if (svunit_pkg::_filter.is_selected(this, tests[i].get_name()))
-        selected_tests.push_back(tests[i]);
-
+    svunit_test selected_tests[] = get_selected_tests();
     if (selected_tests.size() == 0)
       return;
 
@@ -125,6 +121,15 @@ class svunit_testcase extends svunit_base;
     foreach (selected_tests[i])
       run_test(selected_tests[i]);
   endtask
+
+
+  local function array_of_tests get_selected_tests();
+    svunit_test selected_tests[$];
+    foreach (tests[i])
+      if (svunit_pkg::_filter.is_selected(this, tests[i].get_name()))
+        selected_tests.push_back(tests[i]);
+    return selected_tests;
+  endfunction
 
 
   local task run_test(svunit_pkg::svunit_test test);

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -42,6 +42,8 @@ class svunit_testcase extends svunit_base;
   */
   local bit running = 0;
 
+  local bit actually_ran_tests = 0;
+
   local svunit_test tests[$];
   local junit_xml::TestCase current_junit_test_case;
   local junit_xml::TestCase junit_test_cases[$];
@@ -120,6 +122,8 @@ class svunit_testcase extends svunit_base;
     `INFO("RUNNING");
     foreach (selected_tests[i])
       run_test(selected_tests[i]);
+
+    actually_ran_tests = 1;
   endtask
 
 
@@ -302,6 +306,9 @@ endfunction
 */
 function void svunit_testcase::report();
   string success_str = (success)? "PASSED":"FAILED";
+
+  if (!actually_ran_tests)
+    return;
 
   `INFO($sformatf("%0s (%0d of %0d tests passing)",
     success_str,

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -113,10 +113,14 @@ class svunit_testcase extends svunit_base;
 
 
   local task run_tests();
-    `INFO("RUNNING");
+    svunit_test selected_tests[$];
     foreach (tests[i])
       if (svunit_pkg::_filter.is_selected(this, tests[i].get_name()))
-        run_test(tests[i]);
+        selected_tests.push_back(tests[i]);
+
+    `INFO("RUNNING");
+    foreach (selected_tests[i])
+      run_test(selected_tests[i]);
   endtask
 
 

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -118,6 +118,9 @@ class svunit_testcase extends svunit_base;
       if (svunit_pkg::_filter.is_selected(this, tests[i].get_name()))
         selected_tests.push_back(tests[i]);
 
+    if (selected_tests.size() == 0)
+      return;
+
     `INFO("RUNNING");
     foreach (selected_tests[i])
       run_test(selected_tests[i]);

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -454,6 +454,85 @@ endmodule
     assert 'some_passing_test' in log.read_text()
 
 
+@all_available_simulators()
+def test_nothing_printed_for_module_where_no_tests_selected(tmp_path, simulator):
+    unit_test = tmp_path.joinpath('some_unit_test.sv')
+    unit_test.write_text('''
+module some_unit_test;
+
+  import svunit_pkg::*;
+  `include "svunit_defines.svh"
+
+  string name = "some_ut";
+  svunit_testcase svunit_ut;
+
+  function void build();
+    svunit_ut = new(name);
+  endfunction
+
+  task setup();
+    svunit_ut.setup();
+  endtask
+
+  task teardown();
+    svunit_ut.teardown();
+  endtask
+
+  `SVUNIT_TESTS_BEGIN
+
+    `SVTEST(some_test)
+    `SVTEST_END
+
+  `SVUNIT_TESTS_END
+
+endmodule
+    ''')
+
+    other_unit_test = tmp_path.joinpath('some_other_unit_test.sv')
+    other_unit_test.write_text('''
+module some_other_unit_test;
+
+  import svunit_pkg::*;
+  `include "svunit_defines.svh"
+
+  string name = "some_other_ut";
+  svunit_testcase svunit_ut;
+
+  function void build();
+    svunit_ut = new(name);
+  endfunction
+
+  task setup();
+    svunit_ut.setup();
+  endtask
+
+  task teardown();
+    svunit_ut.teardown();
+  endtask
+
+  `SVUNIT_TESTS_BEGIN
+
+    `SVTEST(some_other_test)
+    `SVTEST_END
+
+  `SVUNIT_TESTS_END
+
+endmodule
+    ''')
+
+    print('Nothing should be printed for some_ut')
+    subprocess.check_call(
+            ['runSVUnit',
+                    '-s', simulator,
+                    '--filter', 'some_other_ut.*',
+                    ],
+            cwd=tmp_path)
+
+    with open(pathlib.Path(tmp_path.joinpath('run.log')), 'r') as log:
+        test_case_running = re.compile("some_ut.*RUNNING")
+        assert not any(test_case_running.search(line) for line in log)
+
+
 def test_verilator_does_not_accept_uvm(tmp_path):
     cmdline_usage_error = 4
     returncode = subprocess.call(

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -532,6 +532,10 @@ endmodule
         test_case_running = re.compile("some_ut.*RUNNING")
         assert not any(test_case_running.search(line) for line in log)
 
+    with open(pathlib.Path(tmp_path.joinpath('run.log')), 'r') as log:
+        test_case_running = re.compile("some_ut.*PASSED")
+        assert not any(test_case_running.search(line) for line in log)
+
 
 def test_verilator_does_not_accept_uvm(tmp_path):
     cmdline_usage_error = 4


### PR DESCRIPTION
Fixes #207.

This still prints `RUNNING` messages for test suites that don't have any test cases that actually run any tests. This isn't as annoying as printing `RUNNING` for test cases that don't actually run any tests, because there should be fewer test suites, many times just one.

Tested with:

- [ ] DSim
- [x] QuestaSim
- [ ] VCS
- [x] Verilator
- [x] Vivado
- [x] Xcelium
