### PR TITLE
Hard code version of Ubuntu image to ensure Python 3.6 is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
We want to keep Python 3.6, in case we ever translate the scripts from Perl to Python. Python 3.6 has a chance to be available on the practically ancient OS-es used by hardware companies (e.g. RHEL 7), since it is old enough.

Even though we currently only use Python for testing, if we were to use a newer version right now it might come back to bite us should we ever decide to use Python also for the scripts. This is because we would have to also patch out any test code that relies on newer features.

#### Checklist:

- [ ] tests updated
- [ ] documentation updated
- [ ] CHANGELOG updated


#### Tested with:

- [ ] DSim
- [ ] QuestaSim
- [ ] VCS
- [ ] Verilator
- [ ] Vivado
- [ ] Xcelium
