### PR TITLE
Add Comparison Printout and File + Line Formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add printout on `FAIL_UNLESS_EQUAL` and `FAIL_UNLESS_STR_EQUAL` test failures to make it easier to debug why these tests failes
+- Error printouts now display the file and line number in a way that makes it easier for vscode and other IDEs to link to from the terminal
 
 ## [3.37.1] - 2024-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed experimental code to work after internal refactoring of test execution classes
 - Fix experimental code to avoid clash with included files
 
+### Added
+- Add printout on `FAIL_UNLESS_EQUAL` and `FAIL_UNLESS_STR_EQUAL` test failures to make it easier to debug why these tests failes
 
 ## [3.37.1] - 2024-11-08
 

--- a/docs/source/writing_unit_tests.rst
+++ b/docs/source/writing_unit_tests.rst
@@ -69,6 +69,8 @@ SVUnit includes an integrated reporting mechanism such that the exit PASS/FAIL s
 
 The most commonly used macros are \`FAIL_IF and \`FAIL_UNLESS that take a single boolean expression as input. The \`FAIL_IF_EQUAL and \`FAIL_UNLESS_EQUAL macros exit based on an '===' comparison of boolean inputs a and b. Likewise, \`FAIL_IF_STR_EQUAL and \`FAIL_UNLESS_STR_EQUAL do a string comparison between inputs a and b.
 
+The \`FAIL_UNLESS_EQUAL and \`FAIL_UNLESS_STR_EQUAL mechanisms will report the expected value (b) and actual value (a) to the terminal.
+
 
 Setting Test Exit Status
 ------------------------

--- a/svunit_base/svunit_defines.svh
+++ b/svunit_base/svunit_defines.svh
@@ -68,7 +68,10 @@
 `define FAIL_UNLESS_EQUAL(a,b) \
   begin \
     if (svunit_pkg::current_tc.fail(`"fail_unless_equal`", ((a)!==(b)), `"(a) !== (b)`", `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin \
+        svunit_pkg::current_tc.print_comparison_info(`"fail_unless_equal`", a, b, `__FILE__, `__LINE__); \
+        svunit_pkg::current_tc.give_up(); \
+      end \
     end \
   end
 `endif
@@ -94,7 +97,10 @@
     stra = a; \
     strb = b; \
     if (svunit_pkg::current_tc.fail(`"fail_unless_str_equal`", stra.compare(strb)!=0, $sformatf(`"\"%s\" != \"%s\"`",stra,strb), `__FILE__, `__LINE__)) begin \
-      if (svunit_pkg::current_tc.is_running()) svunit_pkg::current_tc.give_up(); \
+      if (svunit_pkg::current_tc.is_running()) begin \
+        svunit_pkg::current_tc.print_comparison_info(`"fail_unless_equal`", a, b, `__FILE__, `__LINE__); \
+        svunit_pkg::current_tc.give_up(); \
+      end \
     end \
   end
 `endif

--- a/svunit_base/svunit_testcase.sv
+++ b/svunit_base/svunit_testcase.sv
@@ -59,6 +59,7 @@ class svunit_testcase extends svunit_base;
   extern task give_up();
 
   extern function bit fail(string c, logic b, string s, string f, int l, string d = "");
+  extern function void print_comparison_info(string c, int a, int b, string f, int l);
 
   extern function void start();
   extern function void stop();
@@ -243,13 +244,18 @@ function bit svunit_testcase::fail(string c, logic b, string s, string f, int l,
     if (d != "") begin
       $sformat(_d, "[ %s ] ", d);
     end
-    current_junit_test_case.add_failure($sformatf("%s: %s %s(at %s line:%0d)",c,s,_d,f,l));
-    `ERROR($sformatf("%s: %s %s(at %s line:%0d)",c,s,_d,f,l));
+    current_junit_test_case.add_failure($sformatf("%s: %s %s(at %s:%0d)",c,s,_d,f,l));
+    `ERROR($sformatf("%s: %s %s(at %s:%0d)",c,s,_d,f,l));
     return 1;
   end
   else begin
     return 0;
   end
+endfunction
+
+function void svunit_testcase::print_comparison_info(string c, int a, int b, string f, int l);
+  current_junit_test_case.add_failure($sformatf("%s: Expected: %h, Actual: %h (at %s:%0d)",c, b, a, f, l));
+  `ERROR($sformatf("%s: Expected: 0x%0h, Actual: 0x%0h (at %s:%0d)", c, b, a, f, l));
 endfunction
 
 


### PR DESCRIPTION
When trying to debug things quickly, I found having a print statement for the `FAIL_UNLESS_EQUAL` and `FAIL_UNLESS_STR_EQUAL` tests made it much easier. I also found changing how the file and line is formatted when printed out help with `Ctrl+Click` to get the that specific file and line in IDEs like vsCode. 

Here is how the new error will print out:
```bash
ERROR: [190000][counter_wrapper_ut]: fail_unless_equal: (count) !== (8'd1) (at /home/myProject/src/tb/counter_wrapper_unit_test.sv:98)
ERROR: [190000][counter_wrapper_ut]: fail_unless_equal: Expected: 0x1, Actual: 0x0 (at /home/myProject/src/tb/counter_wrapper_unit_test.sv:98)
```
The second error statement will only be printed out for the `FAIL_UNLESS_EQUAL` and `FAIL_UNLESS_STR_EQUAL` tests.

I added documentation that `b` is the expected value and `a` is the actual value. 

#### Checklist:

- [ ] tests updated
- [x] documentation updated
- [x] CHANGELOG updated


#### Tested with:

- [ ] DSim
- [ ] QuestaSim
- [ ] VCS
- [ ] Verilator
- [x] Vivado
- [ ] Xcelium
