### PR TITLE
Add explicit `GITHUB_TOKEN` permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
This is a security recommendation from GitHub's CodeQL checker.

Co-authored-by: tudortimi <8170909+tudortimi@users.noreply.github.com>
Agent-Logs-Url: https://github.com/svunit/svunit/sessions/265b453b-7c1a-46fb-ad3b-7ebad6296027

#### Checklist:

- [ ] tests updated
- [ ] documentation updated
- [ ] CHANGELOG updated


#### Tested with:

- [ ] DSim
- [ ] QuestaSim
- [ ] VCS
- [ ] Verilator
- [ ] Vivado
- [ ] Xcelium
