### PR TITLE
Fix unit tests for experimental code

### DIFF
--- a/src/testExperimental/sv/test_registry_unit_test.sv
+++ b/src/testExperimental/sv/test_registry_unit_test.sv
@@ -117,14 +117,28 @@ module test_registry_unit_test;
 
   class fake_test_builder extends test::builder;
 
+    typedef class fake_test;
+
+
     static function fake_test_builder new_instance();
       new_instance = new();
     endfunction
 
 
     virtual function test create();
-      // Intentionally empty
+      fake_test t = new();
+      return t;
     endfunction
+
+
+    class fake_test extends test;
+      function string name();
+        return "fake_test";
+      endfunction
+
+      protected virtual task test_body();
+      endtask
+    endclass
 
   endclass
 

--- a/sv_test/run
+++ b/sv_test/run
@@ -40,7 +40,7 @@ def prepare_svunit_for_testing():
 
 def clone_stable_version_of_svunit():
     subprocess.check_call(['git', 'clone', 'https://github.com/svunit/svunit.git'])
-    subprocess.check_call(['git', 'checkout', 'v3.36.0'], cwd='svunit')
+    subprocess.check_call(['git', 'checkout', 'v3.38.1'], cwd='svunit')
 
 
 def delete_problematic_directories_that_interfere_with_build():


### PR DESCRIPTION
These were crashing because they weren't creating actual objects for the fake tests. The tests probably never ran for #343.

#### Checklist:

- [ ] tests updated
- [ ] documentation updated
- [ ] CHANGELOG updated


#### Tested with:

- [ ] DSim
- [ ] QuestaSim
- [ ] VCS
- [ ] Verilator
- [ ] Vivado
- [x] Xcelium
